### PR TITLE
Fix serialization of GraphQL responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Fixes:
 
+- Fixed an issue in which certain GraphQL calls responded with
+  `Unable to cast object of type 'Newtonsoft.Json.Linq.JValue'
+  to type 'Newtonsoft.Json.Linq.JObject'.`
+
 New Features:
 
 Breaking Changes:

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
@@ -310,41 +310,7 @@ namespace RubrikSecurityCloud.NetSDK.Client
                 throw new System.Net.Http.HttpRequestException(msg);
             }
 
-            JObject reply = response.Data as JObject;
-            RenameInterfaceFields(reply);
             return response.Data;
-        }
-
-        private void RenameInterfaceFields(JObject replyObject)
-        {
-            const string interfaceFieldId = "_INTERFACE_FIELD_";
-            foreach (JProperty field in replyObject.Properties().ToList())
-            {
-                if (field.Name.Contains(interfaceFieldId))
-                {
-                    string fieldname = field.Name
-                        .Split(
-                            new[] { interfaceFieldId },
-                            StringSplitOptions.RemoveEmptyEntries
-                        )
-                        .Last();
-                    JProperty newField =
-                        new JProperty(fieldname, field.Value);
-                    field.Replace(newField);
-                }
-
-                if (field.Value.Type == JTokenType.Object)
-                {
-                    RenameInterfaceFields(field.Value as JObject);
-                }
-                else if (field.Value.Type == JTokenType.Array)
-                {
-                    foreach (JObject subfield in field.Value)
-                    {
-                        RenameInterfaceFields(subfield);
-                    }
-                }
-            }
         }
 
         private string GraphQLRequestToString(GraphQLRequest request)


### PR DESCRIPTION
Removes code related to aliases, as aliases are not sufficient to handle field name conflicts, and
it is introducing a serialization bug for responses from RSC.

Test Plan:
1. run unit tests
2. verify that the bug is not happening anymore for APIs
that it was occurring for previously