### PR TITLE
Add cmdlet help to Get-RscHelp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,4 +375,5 @@ GraphQL Schme Downloader/schema/.env.json
 
 # PowerShell module
 Output/
+Output.Release/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version 0.28
+
+New Features:
+
+- Added pipe support for SLA Cmdlets
+  [From PR 57](https://github.com/rubrikinc/rubrik-powershell-sdk/pull/57)
+
+Fixes:
+
+- Updated help texts
+  [From PR 53](https://github.com/rubrikinc/rubrik-powershell-sdk/pull/53)
+- Fixed build and tests for PowerShell 5.1
+
 ## Version 0.27
 
 Fixes:

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Invoke-Rsc.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Invoke-Rsc.cs
@@ -122,10 +122,16 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                 {
                     throw new ArgumentException("No GQL query provided");
                 }
-                var _asPathString = Path.GetFullPath(sQuery);
-                if (File.Exists(_asPathString))
-                {
-                    sQuery = File.ReadAllText(_asPathString);
+                
+                // if the content of sQuery is an existing file, read it
+                try {
+                    var _asPathString = Path.GetFullPath(sQuery);
+                    if (File.Exists(_asPathString))
+                    {
+                        sQuery = File.ReadAllText(_asPathString);
+                    }
+                } catch (Exception) {
+                    // ignore
                 }
 
                 GqlQuery = sQuery;

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/New-RscQuery.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/New-RscQuery.cs
@@ -190,7 +190,9 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
 
     }
 
-
+    /// <summary>
+    /// Create a new RscMutation object.
+    /// </summary>
     [CmdletBinding()]
     [Cmdlet(
     "New",
@@ -223,6 +225,9 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
         }
     }
 
+    /// <summary>
+    /// Create a new RscQuery object.
+    /// </summary>
     [CmdletBinding()]
     [Cmdlet(
     "New",

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Public/Get-RscHelp.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Public/Get-RscHelp.psm1
@@ -27,94 +27,104 @@ function Get-RscHelp {
     Param (
         [Parameter(
             ParameterSetName = 'Locations',
-            HelpMessage = 'Show File System locations the SDK uses.',
-            Position = 0
+            HelpMessage = 'Show File System locations the SDK uses.'
         )]
         [Switch]$Locations,
 
         [Parameter(
             ParameterSetName = 'Schema',
-            HelpMessage = 'Look up any symbol in the schema.',
-            Position = 0
+            HelpMessage = 'Look up any symbol in the schema.'
         )]
         [Switch]$Schema,
 
         [Parameter(
             ParameterSetName = 'Query',
-            HelpMessage = 'Look up a query by name.',
-            Position = 0
+            HelpMessage = 'Look up a query by name.'
         )]
         [Switch]$Query,
 
         [Parameter(
             ParameterSetName = 'Mutation',
-            HelpMessage = 'Look up a mutation by name.',
-            Position = 0
+            HelpMessage = 'Look up a mutation by name.'
         )]
         [Switch]$Mutation,
 
         [Parameter(
             ParameterSetName = 'Type',
-            HelpMessage = 'Look up a type by name.',
-            Position = 0
+            HelpMessage = 'Look up a type by name.'
         )]
         [Switch]$Type,
 
         [Parameter(
             ParameterSetName = 'Scalar',
-            HelpMessage = 'Look up a scalar by name.',
-            Position = 0
+            HelpMessage = 'Look up a scalar by name.'
         )]
         [Switch]$Scalar,
 
         [Parameter(
             ParameterSetName = 'Union',
-            HelpMessage = 'Look up a union by name.',
-            Position = 0
+            HelpMessage = 'Look up a union by name.'
         )]
         [Switch]$Union,
 
         [Parameter(
             ParameterSetName = 'Interface',
-            HelpMessage = 'Look up an interface by name.',
-            Position = 0
+            HelpMessage = 'Look up an interface by name.'
         )]
         [Switch]$Interface,
 
         [Parameter(
             ParameterSetName = 'Input',
-            HelpMessage = 'Look up an input by name.',
-            Position = 0
+            HelpMessage = 'Look up an input by name.'
         )]
         [Switch]$Inputs,
 
         [Parameter(
             ParameterSetName = 'Enum',
-            HelpMessage = 'Look up an enum by name.',
-            Position = 0
+            HelpMessage = 'Look up an enum by name.'
         )]
         [Switch]$Enum,
 
         [Parameter(
             ParameterSetName = 'Domain',
-            HelpMessage = 'Look up an API domain by name.',
-            Position = 0
+            HelpMessage = 'Look up an API domain by name.'
         )]
         [Switch]$Domain,
 
         [Parameter(
+            ParameterSetName = 'Cmdlet',
+            HelpMessage = 'This is equivalent to Get-Help -Name <cmdlet> -Full'
+        )]
+        [Switch]$Cmdlet,
+
+        [Parameter(
             HelpMessage = 'Regular expression to match',
-            Position = 1
+            Position = 0
         )]
         [string]$Match = ""
 
     )
     Begin {
+        Write-Debug "=> ParameterSetName: $($PSCmdlet.ParameterSetName) Match: $Match"
         function GetLocationHelp {
+            Write-Debug "Getting locations"
             Get-RscCmdlet -Locations
         }
 
+        function GetCmdletHelp {
+            Write-Debug "Getting cmdlet help for '$Match'"
+            if ($Match -eq "") {
+                $Match = "New-Rsc"
+            }
+            Get-Help -Name $Match -Full
+        }
+
         function LookupSchema {
+            Write-Debug "Looking up schema for '$Match'"
+            if ($Match -imatch "^new-") {
+                GetCmdletHelp
+                return
+            }
             $tableData = @()
             # Get all the enums within the SchemaMeta class
             $enums = [RubrikSecurityCloud.Types.SchemaMeta].GetNestedTypes() | Where-Object { $_.IsEnum -and $_.Name -ne 'GqlRootFieldName' -and $_.Name -ne 'RootFieldKind' }
@@ -149,6 +159,7 @@ function Get-RscHelp {
         }
 
         function LookupQuery {
+            Write-Debug "Looking up query for '$Match'"
             $enumValues = [Enum]::GetValues([RubrikSecurityCloud.Types.SchemaMeta+GqlQueryName]) | Where-Object { $_ -ine 'Unknown' }
             foreach ($value in $enumValues) {
                 # if it's an exact match, print query info
@@ -387,6 +398,7 @@ function Get-RscHelp {
         }
         switch ($PSCmdlet.ParameterSetName) {
             'Locations' { GetLocationHelp }
+            'Cmdlet' { GetCmdletHelp }
             'Schema' { LookupSchema }
             'Query' { LookupQuery }
             'Mutation' { LookupMutation }

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/UpdatePsd1.ps1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/UpdatePsd1.ps1
@@ -1,7 +1,7 @@
 $psdFile = "$PSScriptRoot/RubrikSecurityCloud.psd1"
 $psdContent = Get-Content -Path $psdFile -Raw
 
-$toolkitDir = Join-Path (Get-Item $PSScriptRoot).Parent.Parent.FullName "Toolkit"
+$toolkitDir = Join-Path -Path (Get-Item $PSScriptRoot).Parent.Parent.FullName -ChildPath "Toolkit"
 
 # Update list of ps1xml format files to process:
 $ps1xmlFiles = Get-ChildItem -Path "$toolkitDir/Format" -Filter "*.ps1xml"

--- a/Samples/SampleUtils.ps1
+++ b/Samples/SampleUtils.ps1
@@ -31,8 +31,12 @@ function Write-IndentedWrappedMessage {
         [int] $Indent = 2,
 
         [Parameter(Mandatory=$false)]
-        [int] $Width = ($Host.UI -and $Host.UI.RawUI) ? $Host.UI.RawUI.BufferSize.Width : 80
+        [int] $Width =  80
     )
+
+    if ($Host.UI -and $Host.UI.RawUI) {
+        $Width = $Host.UI.RawUI.BufferSize.Width
+    }
 
     $indentString = " " * $Indent
     $width = $Width - $Indent
@@ -112,7 +116,7 @@ function Wait-ForKey {
     [Console]::TreatControlCAsInput = $true
     $key = [Console]::ReadKey($false)
     Write-Host "`r$('-' * ($Continue.Length + 1))`r"
-    if ($key.Key -eq [System.ConsoleKey]::Escape || ($key.Key -eq [System.ConsoleKey]::C -and $key.Modifiers -eq [System.ConsoleModifiers]::Control)) {
+    if ($key.Key -eq [System.ConsoleKey]::Escape -or ($key.Key -eq [System.ConsoleKey]::C -and $key.Modifiers -eq [System.ConsoleModifiers]::Control)) {
         exit
     }
 }

--- a/Tests/connect.ps1
+++ b/Tests/connect.ps1
@@ -1,8 +1,2 @@
-$ModuleName = 'RubrikSecurityCloud'
-$DllName = $ModuleName + '.psd1'
-$DllDir = '../Output/'
-$DllPath = Join-Path $PSScriptRoot $DllDir $DllName
-
-Remove-Module -Name $ModuleName -ErrorAction 'SilentlyContinue'
-Import-Module $DllPath -Verbose
+. "$PSScriptRoot/../Utils/Import-RscModuleFromLocalOutputDir.ps1" -Quiet
 Connect-Rsc

--- a/Tests/e2e/Get-RscFilesetTemplate.Tests.ps1
+++ b/Tests/e2e/Get-RscFilesetTemplate.Tests.ps1
@@ -31,7 +31,7 @@ Describe -Name 'Get-RscFilesetTemplate' -Tag 'Public' -Fixture{
 
         It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
             { Get-RscFilesetTemplate -Id my-host-id-that-doesnot-exist -Name 'swagsanta' } |
-                Should -Throw "Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided."
+                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscFilesetTemplate'
         }
 
         It -Name 'Parameter OsType cannot be $null' -Test{

--- a/Tests/e2e/Get-RscHost.Tests.ps1
+++ b/Tests/e2e/Get-RscHost.Tests.ps1
@@ -32,7 +32,7 @@ Describe -Name 'Get-RscHost' -Tag 'Public' -Fixture{
 
         It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
             { Get-RscHost -Id my-host-id-that-doesnot-exist -Name 'swagsanta' } |
-                Should -Throw "Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided."
+                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscHost'
         }
 
         It -Name 'Parameter OsType cannot be $null' -Test{

--- a/Tests/e2e/Get-RscVsphereVm.Tests.ps1
+++ b/Tests/e2e/Get-RscVsphereVm.Tests.ps1
@@ -27,7 +27,7 @@ Describe -Name 'Get-RscVSphereVM' -Tag 'Public' -Fixture{
         }
         It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
             { Get-RscVsphereVm -Id VirtualMachine:::1226ff04-6100-454f-905b-5df817b6981a-vm-1025 -Name 'swagsanta' } |
-                Should -Throw "Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided."
+                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscVsphereVm'
         }
     }
 }

--- a/Tests/e2e/Invoke-Rsc.Tests.ps1
+++ b/Tests/e2e/Invoke-Rsc.Tests.ps1
@@ -18,11 +18,17 @@ Describe -Name "Send a generic GraphQL call" -Fixture {
         $response.IsEulaAccepted | Should -Not -BeNullOrEmpty
 
         # Query file with no variables
-        $gqlFile = "$PSScriptRoot\..\..\Samples\queryAccountOwners.gql"
-        $owners = Get-Content -Path $gqlFile -Raw | Invoke-Rsc
+        $gqlFileName = Join-Path -Path $PSScriptRoot -ChildPath "..\..\Samples\queryAccountOwners.gql" -Resolve
+        $gqlContent = Get-Content -Path $gqlFileName -Raw
+        $owners = $gqlContent | Invoke-Rsc
         $owners[0].GetType().Name | Should -BeExactly 'User'
+
         # Same but pass as parameter
-        $owners = Invoke-Rsc (Get-Item -Path $gqlFile).FullName
+        $owners = Invoke-Rsc "$gqlContent"
+        $owners[0].GetType().Name | Should -BeExactly 'User'
+
+        # Same but with a file name
+        $owners = Invoke-Rsc $gqlFileName
         $owners[0].GetType().Name | Should -BeExactly 'User'
 
         # Query file with variables embedded in top comment

--- a/Tests/unit/Import.Tests.ps1
+++ b/Tests/unit/Import.Tests.ps1
@@ -1,21 +1,60 @@
 . "$PSScriptRoot\..\UnitTestInit.ps1"
 
 Describe -Name 'Verify correct import' -Fixture {
-    It "should be version 6.0.0" {
+    It -Name "min version of PowerShell required by the module should be 5.0.0" {
         $module = Get-Module -Name RubrikSecurityCloud
         $expectedVersion = New-Object System.Version(5, 0, 0)
         $module.PowerShellVersion | Should -Be $expectedVersion
     }
+    # Connect-Rsc should always be available
     It -Name 'Connect-Rsc exists' -Test {
         (Get-Command -Name Connect-Rsc -ErrorAction SilentlyContinue) | Out-String |
-            Should -BeLikeExactly '*Connect-Rsc*'
+        Should -BeLikeExactly '*Connect-Rsc*'
     }
+    # Disconnect-Rsc should always be available
     It -Name 'Disconnect-Rsc exists' -Test {
         (Get-Command -Name Disconnect-Rsc -ErrorAction SilentlyContinue) | Out-String |
-            Should -BeLikeExactly '*Disconnect-Rsc*'
+        Should -BeLikeExactly '*Disconnect-Rsc*'
     }
+    # Arbitrary command that should always be available
     It -Name 'Get-RscVsphereVm exists' -Test {
         (Get-Command -Name Get-RscVsphereVm -ErrorAction SilentlyContinue) | Out-String |
-            Should -BeLikeExactly '*Get-RscVsphereVm*'
+        Should -BeLikeExactly '*Get-RscVsphereVm*'
+    }
+
+    # Make sure exported command list is the same on PowerShell 7 and PowerShell 5
+    It -Name 'Exported command list is the same on PowerShell 7 and PowerShell 5' -Test {
+        # Determine if running on Windows
+        $win = $false
+        if ($PSVersionTable.PSVersion.Major -ge 6) {
+            # PowerShell Core/7+
+            $win = $IsWindows
+        }
+        else {
+            # Windows PowerShell 5 ("Desktop PowerShell")
+            $win = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+        }
+
+        if (-not $win) {
+            # Skip this test on non-Windows platforms
+            Set-ItResult -Skipped -Because 'This test is only applicable on Windows'
+            return
+        }
+
+        $sdkDir = Join-Path -Path $PSScriptRoot -ChildPath '..\..' -Resolve
+        $psCommand = ". Utils/Import-RscModuleFromLocalOutputDir.ps1 -Quiet; Get-Command -Module RubrikSecurityCloud | Sort-Object Name | Select-Object -ExpandProperty Name"
+        # Run the command on PowerShell 7
+        $ps7OutFile = "get-command.powershell7.txt"
+        Start-Process -WorkingDirectory $sdkDir -FilePath "pwsh" -ArgumentList "-NoProfile", "-Command", $psCommand -Wait -NoNewWindow -PassThru -RedirectStandardOutput $ps7OutFile
+        # Run the command on PowerShell 5
+        $ps5OutFile = "get-command.powershell5.txt"
+        Start-Process -WorkingDirectory $sdkDir -FilePath "powershell" -ArgumentList "-NoProfile", "-Command", $psCommand -Wait -NoNewWindow -PassThru -RedirectStandardOutput $ps5OutFile
+        # Compare the output
+        $ps7Out = Get-Content -Path $ps7OutFile
+        $ps5Out = Get-Content -Path $ps5OutFile
+        $ps7Out | Should -Be $ps5Out
+        # Clean up
+        Remove-Item -Path $ps7OutFile
+        Remove-Item -Path $ps5OutFile
     }
 }

--- a/Toolkit/Public/Remove-RscSla.ps1
+++ b/Toolkit/Public/Remove-RscSla.ps1
@@ -18,6 +18,9 @@ function Remove-RscSla {
     .PARAMETER Id
     The Id of the SLA which needs to be deleted.
 
+    .PARAMETER GlobalSla
+    The Global Sla which should be removed.
+
     .PARAMETER UserNote
     The user note to be used for auditing the deletion of SLA on
     RSC.
@@ -28,9 +31,14 @@ function Remove-RscSla {
     .EXAMPLE
     Delete an SLA with the given SLA id and usernote
     Remove-RscSLA -SlaId xxx-xxx -UserNote "somestring"
+
+    .EXAMPLE
+    Use the powershell pipe to remove the Global SLA.
+    $result = Get-RscSla -Name 'Sample SLA Domain'
+    $result | Remove-RscSla
     #>
 
-    [CmdletBinding(DefaultParameterSetName = "SuspendSLAInput")]
+    [CmdletBinding(DefaultParameterSetName = "GlobalSlaInput")]
     Param(
         [Parameter(
             ParameterSetName = "RemoveSLAInput",
@@ -49,6 +57,15 @@ function Remove-RscSla {
         [String]$UserNote,
 
         [Parameter(
+            ParameterSetName = "GlobalSlaInput",
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            HelpMessage = "The object representing the 
+                Global SLA which needs to be removed"
+        )]
+        [RubrikSecurityCloud.Types.GlobalSlaReply]$GlobalSla,
+
+        [Parameter(
             Mandatory = $false,
             ValueFromPipeline = $false,
             HelpMessage = "Return the query object instead of running the query"
@@ -57,10 +74,12 @@ function Remove-RscSla {
     )
 
     Process {
-        # Re-use existing connection, or create a new one (stop in case of error):
-        Connect-Rsc -ErrorAction Stop | Out-Null
-
         $query = (New-RscMutationSla -op "DeleteGlobal")
+
+        if ($PsCmdlet.ParameterSetName -eq "GlobalSlaInput") {
+            $SlaId = $GlobalSla.ID
+        }
+
         $query.Var.id = $SlaId
         if( $UserNote ) {
             $query.Var.userNote = $UserNote

--- a/Toolkit/Public/Suspend-RscSla.ps1
+++ b/Toolkit/Public/Suspend-RscSla.ps1
@@ -2,13 +2,13 @@
 function Suspend-RscSla {
     <#
     .SYNOPSIS
-    Resume RSC SLA (service level agreement).
+    Suspend RSC SLA (service level agreement).
     
     .DESCRIPTION
     The Suspend-RscSLA cmdlet is used to suspend a given
     SLA (service level agreement) on one or more clusters
     on which this SLA is applicable.
-    The -SLAId parameter is used for identifying the SLA, 
+    The -SlaId parameter is used for identifying the SLA, 
     this parameter is required.
     The -ClusterUuids specifies a list of cluster Uuids on 
     which this SLA needs to be suspended.
@@ -18,26 +18,34 @@ function Suspend-RscSla {
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
     .PARAMETER SlaId
-    The Id of the SLA which needs to be resumed.
+    The Id of the SLA which needs to be suspended.
 
     .PARAMETER ClusterUuids
-    The cluster IDs on which the SLA needs to be resumed.
+    The cluster IDs on which the SLA needs to be suspended.
+
+    .PARAMETER GlobalSla
+    The Global Sla which should be suspended.
 
     .PARAMETER AsQuery
     Instead of running the command, the query object is returned.
 
     .EXAMPLE
-    Resume an SLA on two clusters on which it is applied.
-    Resume-RscSLA -SlaId xxx-xxx -ClusterUuids yyy-yyy zzz-zzz
+    Suspend an SLA on two clusters on which it is applied.
+    Suspend-RscSLA -SlaId xxx-xxx -ClusterUuids @('yyy-yyy', 'zzz-zzz')
+
+    .EXAMPLE
+    Use the powershell pipe to suspend the Global SLA.
+    $result = Get-RscSla -Name 'Sample SLA Domain'
+    $result | Suspend-RscSla -ClusterUuids @('9c930153-2a3c-4b7d-8603-48145315e71f')
     #>
 
-    [CmdletBinding(DefaultParameterSetName = "SuspendSLAInput")]
+    [CmdletBinding(DefaultParameterSetName = "GlobalSlaInput")]
     Param(
         [Parameter(
             ParameterSetName = "SuspendSLAInput",
             Mandatory = $true,
             ValueFromPipelineByPropertyName = $true,
-            HelpMessage = "The SLA ID which needs to be resumed"
+            HelpMessage = "The ID of the SLA which should be suspended"
         )]
         [String]$SlaId,
 
@@ -47,7 +55,21 @@ function Suspend-RscSla {
             ValueFromPipelineByPropertyName = $true,
             HelpMessage = "The list of cluster UUIDs on which the SLA is applied"
         )]
+        [Parameter(
+            ParameterSetName = "GlobalSlaInput",
+            Mandatory = $true,
+            HelpMessage = "The list of cluster UUIDs on which the SLA is applied"
+        )]
         [String[]]$ClusterUuids,
+
+        [Parameter(
+            ParameterSetName = "GlobalSlaInput",
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            HelpMessage = "The object representing the 
+                Global SLA which needs to be suspended"
+        )]
+        [RubrikSecurityCloud.Types.GlobalSlaReply]$GlobalSla,
 
         [Parameter(
             Mandatory = $false,
@@ -58,10 +80,12 @@ function Suspend-RscSla {
     )
 
     Process {
-        # Re-use existing connection, or create a new one (stop in case of error):
-        Connect-Rsc -ErrorAction Stop | Out-Null
-
         $query = (New-RscMutationSla -op "Pause")
+
+        if ($PsCmdlet.ParameterSetName -eq "GlobalSlaInput") {
+            $SlaId = $GlobalSla.ID
+        }
+
         $pauseSlaInput = Get-RscType -Name "PauseSlaInput" -InitialValues @{
             "slaId" = $SlaId
             "pauseSla" = $true

--- a/Toolkit/Utils/Run-PesterTests.ps1
+++ b/Toolkit/Utils/Run-PesterTests.ps1
@@ -1,4 +1,8 @@
-
+<#
+.SYNOPSIS
+Run Pester tests in a given directory.
+#>
+[CmdletBinding()] # Enable common parameters like -Verbose
 Param(
     [Parameter(Mandatory = $true, Position = 0)]
     [ValidateScript({
@@ -20,42 +24,79 @@ if (-not [System.IO.Path]::IsPathRooted($TestPath)) {
 # Resolve "." and ".." in the path
 $TestPath = (Get-Item -Path $TestPath).FullName
 
+<#
+.SYNOPSIS
+Installs or updates the Pester module to a minimum required version.
+
+.DESCRIPTION
+On PowerShell 7, this function installs or updates the Pester module to 5.3.3 or later.
+On PowerShell 5.1, the pre-installed Pester module (version 3.4.0) is signed by Microsoft
+and updating to a newer version of Pester can result in a digital signature conflict.
+This is because the newer version of Pester might not be signed by Microsoft.
+To address this issue, this function bypasses publisher signature check on PowerShell 5.1.
+
+.NOTES
+It's important to use the `-SkipPublisherCheck` option cautiously,
+as bypassing publisher checks can introduce security risks.
+This function uses it conditionally, only for PowerShell 5.1.
+For environments running newer versions of PowerShell,
+this function does not bypass publisher checks.
+#>
 function InstallOrUpdatePesterIfNeeded {
-    $minimumVersion = [Version]"5.0.0"
+    $minPesterVersion = [Version]"5.3.3"
+    $psVersion = $PSVersionTable.PSVersion
+    $installParams = @{
+        Name = 'Pester';
+        Force = $true;
+        AllowClobber = $true;
+        Scope = 'CurrentUser';
+        SkipPublisherCheck = $psVersion.Major -eq 5 -and $psVersion.Minor -eq 1;
+    }
+    $doInstall = $false
+    
     # Check if Pester is installed and get the version
     $pesterInstalled = Get-Module -ListAvailable -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
 
-    if ($pesterInstalled -and ($pesterInstalled.Version -lt $minimumVersion)) {
-        Write-Output "Pester is installed but the version ($($pesterInstalled.Version)) is lower than the minimum required version ($minimumVersion). Upgrading Pester..."
-        # Upgrade Pester to the latest version
-        Install-Module -Name Pester -Force -AllowClobber -Scope CurrentUser
-        Import-Module -Name Pester -Force
+    if ($pesterInstalled -and ($pesterInstalled.Version -lt $minPesterVersion)) {
+        Write-Host "Pester is installed but the version ($($pesterInstalled.Version)) is lower than the minimum required version ($minPesterVersion). Upgrading Pester..."
+        $doInstall = $true
     }
     elseif (-not $pesterInstalled) {
-        Write-Output "Pester is not installed. Installing the latest version..."
+        Write-Host "Pester is not installed. Installing the latest version..."
+        $doInstall = $true
+    }
+    else {
+        Write-Verbose "Pester is already installed with a compatible version ($($pesterInstalled.Version))."
+    }
 
+    if ($doInstall) {
         # Ensure the user has the necessary permissions
         # and is running the script as an administrator
-        if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-            Write-Error "You need to run this script as an Administrator to install modules (PowerShellGet and Pester)"
-            return
-        }
-
+        # if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        #     Write-Error "You need to run this script as an Administrator to install modules (PowerShellGet and Pester)"
+        #     return
+        # }
+    
         # Update the PowerShellGet module first to avoid issues
         Install-Module -Name PowerShellGet -Force -AllowClobber -Scope CurrentUser
 
-        # Now install Pester
-        Install-Module -Name Pester -Force -RequiredVersion $minimumVersion -AllowClobber -Scope CurrentUser
-    } else {
-        Write-Verbose "Pester is already installed with a compatible version ($($pesterInstalled.Version))."
+        # Upgrade Pester to the latest version
+        Install-Module @installParams
     }
+
+    # Re-import the Pester module to ensure the updated version is used
+    Import-Module -Name Pester -Force
 }
 
 # Call the function to ensure Pester is installed and >= 5.0.0
 InstallOrUpdatePesterIfNeeded
 
 $p = Get-Item -Path $TestPath
-$displayPath = Join-Path $p.Parent.Parent.Name $p.Parent.Name $p.Name
+if ($PSVersionTable.PSVersion.Major -eq 5) {
+    $displayPath = $p.FullName
+} else {
+    $displayPath = Join-Path $p.Parent.Parent.Name $p.Parent.Name $p.Name
+}
 Write-Host "`n[$($p.Name)] Running Pester tests in $displayPath" -ForegroundColor Cyan
 
 # Run Pester tests and pass through the results

--- a/Utils/Import-RscModuleFromLocalOutputDir.ps1
+++ b/Utils/Import-RscModuleFromLocalOutputDir.ps1
@@ -14,8 +14,7 @@ Note2: the script can also be called with `-System`, in which case
 it'll import the one that's installed on the system.
 #>
 
-[CmdletBinding(
-)]
+[CmdletBinding()]
 param(
     [Parameter(
         Mandatory = $false,

--- a/Utils/New-RscSdkRelease.ps1
+++ b/Utils/New-RscSdkRelease.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+ADMIN USE ONLY. Update the GitHub repo's main branch and create a new release.
+
+.DESCRIPTION
+ADMIN USE ONLY: this script updates the GitHub repo and needs to be run by an admin.
+Running it as a non-admin will not alter the repository and
+will only show what would have been done.
+
+NOTE: This script runs in dry mode by default unless -NotDry is given.
+You can safely run New-RscSdkRelease.ps1
+to see what would have been done without actually doing it.
+
+This script will:
+1. Get the latest changelog entry
+2. Run Update-RscSdkMainBranch.ps1 to update the main branch
+5. Commit the changes with the latest version entry as the commit message
+6. Push the changes to the main branch
+7. Create a new GitHub release
+
+.EXAMPLE
+.\Utils\New-RscSdkRelease.ps1
+#>
+param(
+    [switch]$NotDry = $false
+)
+
+function RunIfNotDry {
+    param(
+        [ScriptBlock]$CodeBlock
+    )
+
+    # Check if the global variable $NotDry is set and not false
+    if ($script:NotDry) {
+        Write-Output "Run: $($CodeBlock.ToString())"
+        try {
+            # Execute the script block
+            & $CodeBlock
+        }
+        catch {
+            throw "Failed to execute $($CodeBlock.ToString()): $_"
+        }
+    }
+    else {
+        # Print the script block without executing
+        Write-Output "Dry run: $($CodeBlock.ToString())"
+    }
+}
+
+# Change to the root of the repository
+Set-Location $PSScriptRoot\..
+
+$changelogScriptPath = ".\Utils\Get-RscSdkLatestChangelog.ps1"
+$changelogLatest = & $changelogScriptPath
+if ( -Not $changelogLatest ) {
+    throw "Failed to get the latest changelog entry."
+}
+$versionTag = $changelogLatest.latestVersionTag
+$versionEntry = $changelogLatest.latestVersionEntry
+
+Write-Host "Latest version tag: " -NoNewline
+Write-Host $versionTag -ForegroundColor Cyan
+Write-Host "Latest version entry:"
+Write-Host $versionEntry -ForegroundColor Cyan
+
+# Update main branch
+$CommitMessage = ""
+RunIfNotDry {
+    $script:CommitMessage = $versionEntry
+}
+.\Utils\Update-RscSdkMainBranch.ps1 -CommitMessage "$CommitMessage"
+
+# Create a new GitHub release
+RunIfNotDry {
+    gh release create $versionTag -t $versionTag -n "$versionEntry"
+}
+
+# Prepare devel branch for further development
+RunIfNotDry {
+    git checkout devel
+    Set-Location $PSScriptRoot\..
+    .\Utils\New-RscSdkChangeLogEntry.ps1 -Commit
+    git push origin devel
+}
+
+Write-Host "Done." -ForegroundColor Green
+Write-Host "git status:"
+git status

--- a/Utils/Test-RscSdk.ps1
+++ b/Utils/Test-RscSdk.ps1
@@ -36,6 +36,7 @@
     .\Utils\Test-RscSdk.ps1 -SkipE2ETests -SkipCoreTests
     # Run only Toolkit unit tests.
 #>
+[CmdletBinding()] # Enable common parameters like -Verbose
 param(
     [switch]$SkipUnitTests = $false,
     [switch]$SkipE2ETests = $false,
@@ -48,6 +49,9 @@ Set-Location $PSScriptRoot\..
 
 # Stop on error
 $ErrorActionPreference = "Stop"
+
+# Uncomment this to enable Write-Debug output
+# $DebugPreference = "Continue"
 
 # Set up
 if ($CI) {
@@ -64,7 +68,8 @@ if ($CI) {
         Set-Location $PSScriptRoot\..
         .\Utils\Import-RscModuleFromLocalOutputDir.ps1
         Set-RscServiceAccountFile -InputFilePath $serviceAccountFile -DisablePrompts -KeepOriginalClearTextFile
-    } else {
+    }
+    else {
         throw "SA Unavailable (Environment variable RSC_SERVICE_ACCOUNT_FILE not set)."
     }
 }
@@ -78,7 +83,8 @@ if ( -not $SkipUnitTests ) {
         if ($results.Failed.Count -gt 0) {
             Write-Error "Pester Core unit tests failed."
             exit 1
-        } else {
+        }
+        else {
             Write-Output "Pester Core unit tests passed."
         }
 
@@ -88,7 +94,8 @@ if ( -not $SkipUnitTests ) {
         if ($LASTEXITCODE -ne 0) {
             Write-Error "C# unit tests failed."
             exit $LASTEXITCODE
-        } else {
+        }
+        else {
             Write-Output "C# unit tests passed."
         }
 
@@ -102,7 +109,8 @@ if ( -not $SkipUnitTests ) {
         if ($results.Failed.Count -gt 0) {
             Write-Error "Pester Toolkit unit tests failed."
             exit 1
-        } else {
+        }
+        else {
             Write-Output "Pester Toolkit unit tests passed."
         }
     }
@@ -116,7 +124,8 @@ if ( -not $SkipE2ETests ) {
         if ($results.Failed.Count -gt 0) {
             Write-Error "Pester Core e2e tests failed."
             exit 1
-        } else {
+        }
+        else {
             Write-Output "Pester Core e2e tests passed."
         }
     }
@@ -128,7 +137,8 @@ if ( -not $SkipE2ETests ) {
         if ($results.Failed.Count -gt 0) {
             Write-Error "Pester Toolkit e2e tests failed."
             exit 1
-        } else {
+        }
+        else {
             Write-Output "Pester Toolkit e2e tests passed."
         }
     }

--- a/Utils/Update-RscSdkMainBranch.ps1
+++ b/Utils/Update-RscSdkMainBranch.ps1
@@ -11,43 +11,22 @@ You can safely run: .\Utils\Update-RscSdkMainBranch.ps1 -SkipBuild
 to see what would have been done without actually doing it.
 
 This script will:
-1. Check out the main branch
-2. Merge the devel branch into main without committing
-3. Build the SDK (unless -SkipBuild is given)
-4. Get the latest changelog entry
-5. Commit the changes with the latest version entry as the commit message
-6. Push the changes to the main branch
-7. Create a new GitHub release
+1. Check out the main branch;
+2. Merge the devel branch into main without committing;
+3. Build the SDK (unless -SkipBuild is given);
+4. If a commit message is given, commit and push the changes to the main branch.
+
+.PARAMETER CommitMessage
+If not given, the script will not commit or push the changes to the main branch,
+so it is effectively a dry run.
 
 .EXAMPLE
 .\Utils\Update-RscSdkMainBranch.ps1 -SkipBuild
 #>
 param(
     [switch]$SkipBuild = $false,
-    [switch]$NotDry = $false
+    [string]$CommitMessage = ""
 )
-
-function RunIfNotDry {
-    param(
-        [ScriptBlock]$CodeBlock
-    )
-
-    # Check if the global variable $NotDry is set and not false
-    if ($script:NotDry) {
-        Write-Output "Run: $($CodeBlock.ToString())"
-        try {
-            # Execute the script block
-            & $CodeBlock
-        }
-        catch {
-            throw "Failed to execute $($CodeBlock.ToString()): $_"
-        }
-    }
-    else {
-        # Print the script block without executing
-        Write-Output "Dry run: $($CodeBlock.ToString())"
-    }
-}
 
 # Change to the root of the repository
 Set-Location $PSScriptRoot\..
@@ -89,48 +68,21 @@ catch {
     throw "Failed to merge 'devel' into 'main'."
 }
 
-# Build the SDK
+# Build the SDK on the main branch
 try {
     if (-not $SkipBuild) {
-        .\Utils\Build-RscSdk.ps1
+        .\Utils\Build-RscSdk.ps1 -Release
     }
 }
 catch {
     throw "Failed to build the SDK."
 }
 
-$changelogScriptPath = Join-Path -Path $PSScriptRoot -ChildPath "Get-RscSdkLatestChangelog.ps1"
-$changelogLatest = & $changelogScriptPath
-if ( -Not $changelogLatest ) {
-    throw "Failed to get the latest changelog entry."
-}
-$versionTag = $changelogLatest.latestVersionTag
-$versionEntry = $changelogLatest.latestVersionEntry
 
-Write-Host "Latest version tag: " -NoNewline
-Write-Host $versionTag -ForegroundColor Cyan
-Write-Host "Latest version entry:"
-Write-Host $versionEntry -ForegroundColor Cyan
-
-# Commit changes with the latest version entry as the commit message
-git commit -a -m "$versionEntry"
-
-# Push the changes to the main branch
-RunIfNotDry {
+# Commit and push the changes to the main branch
+if ($CommitMessage) {
+    git commit -a -m "$CommitMessage"
     git push origin main
-}
-
-# Create a new GitHub release
-RunIfNotDry {
-    gh release create $versionTag -t $versionTag -n "$versionEntry"
-}
-
-# Prepare devel branch for further development
-RunIfNotDry {
-    git checkout devel
-    Set-Location $PSScriptRoot\..
-    .\Utils\New-RscSdkChangeLogEntry.ps1 -Commit
-    git push origin devel
 }
 
 Write-Host "Done." -ForegroundColor Green


### PR DESCRIPTION
- ignore Output.Release directory
- Refactor Tests and Toolkit scripts to work on both PowerShell 7 and 5.1
- Add pipe support for SLA Cmdlets (#57)
- Test to make sure exported command list is the same on PowerShell 7 and PowerShell 5 (#56)
- split Update-RscMainBranch to New-RscSdkRelease
- Add cmdlet help access from Get-RscHelp
