### PR TITLE
Update the operation name for SnapshotListQuery

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscSnapshot.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscSnapshot.cs
@@ -229,7 +229,7 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
             queryText += queryFragment;
             queryText += "\n}";
 
-            request.OperationName = "SnapshotListQuery";
+            request.OperationName = "SnapshotOfAsnappableConnection";
             request.Query = queryText;
 
             return request;


### PR DESCRIPTION
While debugging an [issue](https://rubrik.atlassian.net/browse/SPARK-355688) I got confused due to conflicting names in RSC spark UI and our powershell SDK.
So the [Get-RscSnapshot](https://github.com/rubrikinc/rubrik-powershell-sdk/blob/5b5fa89f3e9908fe98facc1501b4220d0bd46bc1/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscSnapshot.cs) uses the operation name as SnapshotListQuery but it should be SnapshotOfASnappableConnection . There is another SnapshotListQuery operation in the UI code which basically gets some information from hierarchyObjects.
So I confused both of them and also the owner of both these APIs were different (Platform and DLC). I guess we should update the operation name in the powershell cmdlet.
This will help us get rid of this confusion and also help us reach out to the right team when a CFD pops up, etc.