### PR TITLE
Get-RscWorkload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ New Features:
 - New-RscNasSystem for registering a new NAS system with RSC.
 - Schema Update
 
+ - Get-RscWorkload cmdlet - Retrieves information about any supported workload type, with various filtering capabilities.
+
 Fixes:
 - Issue [#86](https://github.com/rubrikinc/rubrik-powershell-sdk/issues/86)
 - Issue [#96](https://github.com/rubrikinc/rubrik-powershell-sdk/issues/96)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # Changelog
 
+<<<<<<< HEAD
 ## ~ Upcoming Version ~
 
 New Features:
+=======
+## Upcoming Release
+
+New Features:
+  - Get-RscWorkload cmdlet - Retrieves information about any supported workload type, with various filtering capabilities.
+>>>>>>> c69ad7d1 (changelog update)
 
 Fixes:
 
 Breaking Changes:
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> c69ad7d1 (changelog update)
 ## Version 1.4
 
 New Features:
@@ -16,8 +27,6 @@ New Features:
 - Get-RscNasSystem for getting details of NAS systems.
 - New-RscNasSystem for registering a new NAS system with RSC.
 - Schema Update
-
- - Get-RscWorkload cmdlet - Retrieves information about any supported workload type, with various filtering capabilities.
 
 Fixes:
 - Issue [#86](https://github.com/rubrikinc/rubrik-powershell-sdk/issues/86)

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.psd1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.psd1
@@ -63,7 +63,8 @@ PowerShellVersion = '5.0.0'
 # Format files (.ps1xml) to be loaded when importing this module
 FormatsToProcess = @(
   "Toolkit/Format/GlobalSlaReply.Format.ps1xml",
-  "Toolkit/Format/VsphereVm.Format.ps1xml")
+  "Toolkit/Format/VsphereVm.Format.ps1xml",
+  "Toolkit/Format/Snappable.Format.ps1xml")
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @('PublicFunctions.psm1')

--- a/Toolkit/Format/Snappable.Format.ps1xml
+++ b/Toolkit/Format/Snappable.Format.ps1xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+    <ViewDefinitions>
+        <View>
+            <Name>Default</Name>
+            <ViewSelectedBy>
+                <TypeName>RubrikSecurityCloud.Types.Snappable</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Name</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object Type</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Object State</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Compliance Status</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Sla Domain</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Forever Id (FID)</Label>
+                    </TableColumnHeader>                      
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>objectType</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>objectState</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                               <PropertyName>complianceStatus</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                 <ScriptBlock>$_.slaDomain.name</ScriptBlock>
+                            </TableColumnItem>                            
+                            <TableColumnItem>
+                                <PropertyName>fid</PropertyName>
+                            </TableColumnItem>                            
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/Toolkit/Public/Get-RscWorkload.ps1
+++ b/Toolkit/Public/Get-RscWorkload.ps1
@@ -1,0 +1,199 @@
+#Requires -Version 3
+function Get-RscWorkload {
+    <#
+    .SYNOPSIS
+    Retrieves list of protectable objects in Rubrik Security Cloud
+
+    .DESCRIPTION
+    This cmdlet uses the GQL query 'snappableConnection' to retrieve a list of protectable objects with a predetermined set of properties.
+
+    .LINK
+    Schema reference:
+    https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
+
+    .EXAMPLE
+    # Get all Workloads
+    Get-RscWorkload
+
+    .EXAMPLE
+    # Get Workload with specific name
+    Get-RscWorkload -Name "jake-001"
+
+    .EXAMPLE
+    # Get Workloads by object type
+    Get-RscWorkload -Type WINDOWS_FILESET
+    
+    .EXAMPLE 
+    # Get all workloads from a specific SLA
+    Get-RscSla -Name "Gold" | Get-RscWorkload
+
+    .EXAMPLE
+    # Get all out of compliance workloads on a specific Rubrik Cluster
+    Get-RscCluster -Name "MyCluster" | Get-RscWorkload -ComplianceStatus OUT_OF_COMPLIANCE
+
+    .EXAMPLE
+    # Get workload with specific RSC ID
+    Get-RscWorkload -Id "76CEDF7F-A65E-4264-9DE2-B918CA3CE15D"
+
+    .EXAMPLE
+    # Get workload with specific CDM ID
+    Get-RscWorkload -CdmId "MssqlDatabase:::76CEDF7F-A65E-4264-9DE2-B918CA3CE15D" -Cluster (Get-RscCluster -Name "MyCluster")
+
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(
+            Mandatory = $false,
+            ParameterSetName = "CdmId"
+        )]
+        [String]$CdmId,
+        [Parameter(
+            Mandatory = $false,
+            ParameterSetName = "Id"
+        )]
+        [String[]]$Id,
+        [Parameter(
+            Mandatory = $false
+        )]
+        [RubrikSecurityCloud.Types.ObjectTypeEnum[]]$Type,
+        [Parameter(
+            Mandatory = $false
+        )]
+        [RubrikSecurityCloud.Types.ObjectTypeEnum[]]$ExcludeType,
+        [Parameter(
+            Mandatory = $false
+        )]
+        [RubrikSecurityCloud.Types.ObjectState[]]$State,
+        [Parameter(
+            Mandatory = $false
+        )]
+        [RubrikSecurityCloud.Types.ComplianceStatusEnum[]]$ComplianceStatus,
+        [Parameter(
+            Mandatory = $false
+        )]
+        [RubrikSecurityCloud.Types.ProtectionStatusEnum[]]$ProtectionStatus,
+        [Parameter(
+            Mandatory = $false
+        )]
+        [String]$SearchTerm,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $true
+        )]
+        [RubrikSecurityCloud.Types.GlobalSlaReply]$Sla,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $true
+        )]
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $true
+        )]
+        [RubrikSecurityCloud.Types.Org]$Org
+    )
+    
+    Process {
+
+        $query = New-RscQuery -GqlQuery snappableConnection -FieldProfile EMPTY
+        $query.Field.Nodes[0].Id = "FOO"
+        $query.Field.Nodes[0].Location = "FOO"
+        $query.Field.Nodes[0].complianceStatus = [RubrikSecurityCloud.Types.ComplianceStatusEnum]::IN_COMPLIANCE
+        $query.Field.Nodes[0].protectionStatus = [RubrikSecurityCloud.Types.ProtectionStatusEnum]::PROTECTED
+        $query.Field.Nodes[0].objectType = [RubrikSecurityCloud.Types.ObjectTypeEnum]::VMWARE_VIRTUAL_MACHINE
+        $query.Field.Nodes[0].objectState = [RubrikSecurityCloud.Types.ObjectState]::ACTIVE
+        $query.Field.Nodes[0].protectedOn = [System.Datetime]"1/1/2000"
+        $query.Field.Nodes[0].totalSnapshots = 1
+        $query.Field.Nodes[0].missedSnapshots = 1
+        $query.Field.Nodes[0].lastSnapshot = [System.Datetime]"1/1/2000"
+        $query.Field.Nodes[0].latestArchivalSnapshot = [System.Datetime]"1/1/2000"
+        $query.Field.Nodes[0].latestReplicationSnapshot = [System.Datetime]"1/1/2000"
+        $query.Field.Nodes[0].localOnDemandSnapshots = 1
+        $query.Field.Nodes[0].localSlaSnapshots = 1
+        $query.Field.Nodes[0].archivalSnapshotLag = 1
+        $query.Field.Nodes[0].replicationSnapshotLag = 1
+        $query.Field.Nodes[0].archivalComplianceStatus = [RubrikSecurityCloud.Types.ComplianceStatusEnum]::IN_COMPLIANCE
+        $query.Field.Nodes[0].replicationComplianceStatus = [RubrikSecurityCloud.Types.ComplianceStatusEnum]::IN_COMPLIANCE
+        $query.Field.Nodes[0].awaitingFirstFull = $true
+        $query.Field.Nodes[0].pullTime = [System.Datetime]"1/1/2000"
+        $query.Field.Nodes[0].location = "FOO"
+        $query.Field.Nodes[0].localStorage = 1
+        $query.Field.Nodes[0].localMeteredData = 1
+        $query.Field.Nodes[0].usedBytes = 1
+        $query.Field.Nodes[0].provisionedBytes = 1
+        $query.Field.Nodes[0].localProtectedData = 1
+        $query.Field.Nodes[0].localEffectiveStorage = 1
+        $query.Field.Nodes[0].lastSnapshotLogicalBytes = 1
+        $query.Field.Nodes[0].orgId = "FOO"
+        $query.Field.Nodes[0].sourceProtocol = "FOO"
+        $query.Field.Nodes[0].ncdPolicyName = "FOO"
+        $query.Field.Nodes[0].ncdLatestArchiveSnapshot = [System.Datetime]"1/1/2000"
+        $query.Field.Nodes[0].slaDomain = New-Object RubrikSecurityCloud.Types.GlobalSlaReply
+        $query.Field.Nodes[0].slaDomain.name = "FOO"
+        $query.Field.Nodes[0].slaDomain.id = "FOO"
+        $query.Field.Nodes[0].cluster = New-Object RubrikSecurityCloud.Types.Cluster
+        $query.Field.Nodes[0].cluster.name = "FOO"
+        $query.Field.Nodes[0].cluster.id = "FOO"
+        $query.Field.Nodes[0].fid = "FOO"
+        $query.Field.Nodes[0].localSnapshots = 1
+        $query.Field.Nodes[0].replicaSnapshots = 1
+        $query.Field.Nodes[0].physicalBytes = 1
+        $query.Field.Nodes[0].transferredBytes = 1
+        $query.Field.Nodes[0].logicalBytes = 1
+        $query.Field.Nodes[0].replicaStorage = 1
+        $query.Field.Nodes[0].archiveStorage = 1
+        $query.Field.Nodes[0].dataReduction = 1
+        $query.Field.Nodes[0].logicalDataReduction = 1
+        $query.Field.Nodes[0].workloadOrg = New-Object RubrikSecurityCloud.Types.WorkloadOrganization
+        $query.Field.Nodes[0].workloadOrg.name = "FOO"
+        $query.Field.Nodes[0].workloadOrg.id = "FOO"
+
+        $query.var.filter = New-Object -TypeName RubrikSecurityCloud.Types.SnappableFilterInput
+
+        if ($CdmId) {
+            if (!$Cluster) {
+                throw "Must provide Cluster to get workload by CDM ID"
+            }
+            else {
+                # Run workloadForeverId, add Id to snappableConnectionFilter then run snappableConnection
+                $fidQuery = New-RscQuery -GqlQuery workloadForeverId
+                $fidQuery.var.clusterUuid = $Cluster.Id
+                $fidQuery.var.managedId = $CdmId
+                $fidQueryResult = Invoke-Rsc $fidQuery
+                $ForeverId = $fidQueryResult
+                $Id = $ForeverId
+            }
+        }
+        if ($Type) {
+            $query.var.filter.objectType = $Type
+        }
+        if ($Id) {
+            $query.var.filter.ObjectFid = $Id
+        }
+        if ($State) {
+            $query.var.filter.objectState = $State
+        }
+        if ($ComplianceStatus) {
+            $query.var.filter.complianceStatus = $ComplianceStatus
+        }
+        if ($ProtectionStatus) {
+            $query.var.filter.protectionStatus = $ProtectionStatus
+        }
+        if ($Sla) {
+            $slaFilter = New-Object -TypeName RubrikSecurityCloud.Types.SnappableSlaDomainFilterInput
+            $slaFilter.Id = $Sla.Id
+            $query.var.filter.slaDomain = $slaFilter
+        }
+        if ($Cluster) {
+            $clusterFilter = New-Object -TypeName RubrikSecurityCloud.Types.CommonClusterFilterInput
+            $clusterFilter.Id = $Cluster.Id
+            $query.var.filter.cluster = $clusterFilter
+        }
+        if ($Org) {
+            $query.var.filter.orgId = $Org.Id
+        }
+
+        $result = Invoke-Rsc -Query $query
+        $result.nodes
+    }
+}

--- a/Toolkit/Public/Get-RscWorkload.ps1
+++ b/Toolkit/Public/Get-RscWorkload.ps1
@@ -40,7 +40,7 @@ function Get-RscWorkload {
     Get-RscWorkload -CdmId "MssqlDatabase:::76CEDF7F-A65E-4264-9DE2-B918CA3CE15D" -Cluster (Get-RscCluster -Name "MyCluster")
 
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = "Name")]
     Param(
         [Parameter(
             Mandatory = $false,


### PR DESCRIPTION
* Added Get-RscWorkload cmdlet (Uses snappableConnection and workloadForeverId queries)
* Added format file for snappable type

Get-RscWorkload is a veritable swiss army knife. A lot of RSC reports use the same underlying queries, making this an excellent cmdlet for ad-hoc scripted reports. Additionally, This cmdlet can be used to Get RSC IDs given a CDM ID, and vice versa. There are many filtering capabilities, which an help answer the questions "What objects are in a particular SLA" or "What objects are out of compliance on a specific cluster"