### PR TITLE
Fix Issue-112 Get-RscType nested fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ New Features:
   - Get-RscVmwareVm - Added -Relic switch. Use -Relic:$false to filter out Relics. -Relic will return only Relics. No usage of -Relic will return all (default operation). -Name parameter is now position 0, so you don't have to specify -Name.
   - Get-RscNutanixVm - New cmdlet to get Nutanix VMs
   - Register-RscRubrikBackupService - New cmdlet to register RBS on VMs
+  - New-RscSla - Now accepts -DailySchedule as a parameter
 
 Fixes:
+  - Issue [#112](https://github.com/rubrikinc/rubrik-powershell-sdk/issues/112)
 
 Breaking Changes:
 

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscTypeInitializer.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscTypeInitializer.cs
@@ -308,11 +308,11 @@ namespace RubrikSecurityCloud.PowerShell.Private
                             }
                             else
                             {
-                                IList value = (IList)returnInstance.GetType()
+                                IList value = (IList)currentObject?.GetType()?
                                     .GetProperty(requestedPropertyTree[i],
                                     BindingFlags.IgnoreCase |
                                     BindingFlags.Instance |
-                                    BindingFlags.Public).GetValue(returnInstance);
+                                    BindingFlags.Public)?.GetValue(currentObject);
                                 currentObject = value[0];
                             }
 


### PR DESCRIPTION
This is a bugfix for Get-RscType where -InitialProperties only initialized the first requested property of a nested property tree as described in [Issue-112](https://github.com/rubrikinc/rubrik-powershell-sdk/issues/112)
