### PR TITLE
Access token renewal is not stored in PowerShell session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.8
+
+Fixes:
+
+- Fixed an issue with access token auto-renewal not being saved in the
+  PowerShell session (rseulting in multiple token renew calls).
+
 ## Version 1.7
 
 Fixes:

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLInterfaceConverter.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLInterfaceConverter.cs
@@ -64,7 +64,7 @@ public class GraphQLInterfaceConverter : JsonConverter
             {
                 if (RubrikSecurityCloud.Config.MuteSchemaWarnings)
                 {
-                    _logger?.Info(msg);
+                    _logger?.Verbose(msg);
                 }
                 else
                 {
@@ -99,7 +99,7 @@ public class GraphQLInterfaceConverter : JsonConverter
             {
                 if (RubrikSecurityCloud.Config.MuteSchemaWarnings)
                 {
-                    _logger?.Info(msg);
+                    _logger?.Verbose(msg);
                 }
                 else
                 {

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Disconnect-Rsc.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Disconnect-Rsc.cs
@@ -11,13 +11,28 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
     [Cmdlet(VerbsCommunications.Disconnect, "Rsc")]
     public class Disconnect_Rsc : RscBasePSCmdlet
     {
-        public Disconnect_Rsc() : base(retrieveConnection: true)
+        private bool _doDisconnect = true;
+        public Disconnect_Rsc() : base(retrieveConnection: false)
         {
+        }
+
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            if(!this.RetrieveConnection(throwIfNotRetrieved:false))
+            {
+                this._doDisconnect=false;
+                WriteObject("No connection to disconnect from.");
+            }
         }
 
         protected override void ProcessRecord()
         {
             base.ProcessRecord();
+            if(!_doDisconnect)
+            {
+                return;
+            }
             try
             {
                 Task delSessionTask = this._rbkClient.Disconnect();
@@ -27,6 +42,10 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                 if (SessionState.PSVariable.GetValue(Config.SessionVariableName) == null)
                 {
                     WriteObject("The Rubrik Security Cloud session has been terminated.");
+                }
+                else
+                {
+                    WriteObject("Could not remove the Rubrik Security Cloud session variable. Please remove it manually.");
                 }
             }
             catch (Exception ex)

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscLogger.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscLogger.cs
@@ -48,7 +48,7 @@ namespace RubrikSecurityCloud.PowerShell.Private
         }
         public void Verbose(string message)
         {
-            var m = ($"{name}: {message}");
+            var m = ($"[{name}] {message}");
             if (_cmdlet != null)
             {
                 this._logQueue.Enqueue("V" + m);
@@ -62,7 +62,7 @@ namespace RubrikSecurityCloud.PowerShell.Private
 
         public void Info(string message)
         {
-            var m = ($"{name}: {message}");
+            var m = ($"[{name}] {message}");
             if (_cmdlet != null)
             {
                 this._logQueue.Enqueue("I" + m);
@@ -76,7 +76,7 @@ namespace RubrikSecurityCloud.PowerShell.Private
 
         public void Warning(string message)
         {
-            var m = ($"{name}: {message}");
+            var m = ($"[{name}] {message}");
             if (_cmdlet != null)
             {
                 this._logQueue.Enqueue("W" + m);
@@ -90,7 +90,7 @@ namespace RubrikSecurityCloud.PowerShell.Private
 
         public void Error(string message)
         {
-            var m = ($"{name}: {message}");
+            var m = ($"[{name}] {message}");
             if (_cmdlet != null)
             {
                 this._logQueue.Enqueue("E" + m);

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.psd1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.psd1
@@ -8,7 +8,7 @@
 RootModule = 'LoadModule.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.7'
+ModuleVersion = '1.8'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
When an access token is expired, the SDK renews it - but does not store it in the PowerShell session , so the next cmdlet calls will all renew the token too.