### PR TITLE
Enable logging in PowerShell sub-sessions

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
@@ -268,7 +268,7 @@ namespace RubrikSecurityCloud.NetSDK.Client
 
             HttpClient apiClient = new HttpClient(loggingHandler)
             {
-                BaseAddress = new Uri($"{_polarisUrlScheme}://{_polarisBaseUrl}")
+                BaseAddress = this.ServerBaseAddress()
             };
             apiClient.Timeout = TimeSpan.FromMinutes(
                 RubrikSecurityCloud.Config.ApiClientTimeOutMinutes

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscGqlPSCmdlet.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscGqlPSCmdlet.cs
@@ -468,17 +468,25 @@ namespace RubrikSecurityCloud.PowerShell.Private
                 return;
             }
 
-            if (_config.SendQueryOnExitIfAny && _query != null)
+            if (this._query != null)
             {
-                RscGqlRequest gqlReq = _query.GqlRequest();
-                if (gqlReq != null && _rbkClient != null)
+                if (this.MyInvocation.BoundParameters.ContainsKey("Verbose"))
                 {
-                    this.SendGqlRequest(gqlReq);
+                    this._query.InvokedWithVerboseFlag = true;
                 }
-            }
-            else
-            {
-                if (_query != null)
+                if (this.MyInvocation.BoundParameters.ContainsKey("Debug"))
+                {
+                    this._query.InvokedWithDebugFlag = true;
+                }
+                if (_config.SendQueryOnExitIfAny)
+                {
+                    RscGqlRequest gqlReq = _query.GqlRequest();
+                    if (gqlReq != null && _rbkClient != null)
+                    {
+                        this.SendGqlRequest(gqlReq);
+                    }
+                }
+                else
                 {
                     //InterfaceHelper.ConvertListsToRscInterfaces(_query.Field);
                     this.WriteObject(_query);

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscQuery.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscQuery.cs
@@ -37,6 +37,8 @@ namespace RubrikSecurityCloud
         internal IRscLogger Logger = null;
         internal string OperationsDir = null;
         internal string CustomOperationsDir = null;
+        internal bool InvokedWithDebugFlag = false;
+        internal bool InvokedWithVerboseFlag = false;
 
         // temporary until Op becomes an RscOp
         internal RscOp? rscOp { get; set; } = null;
@@ -113,6 +115,18 @@ namespace RubrikSecurityCloud
             {
                 powerShell.AddCommand("Invoke-Rsc")
                     .AddParameter("Query", this);
+
+                // Check if the parent cmdlet is called with -Verbose and/or -Debug
+                if (this.InvokedWithVerboseFlag)
+                {
+                    powerShell.AddParameter("Verbose", true);
+                }
+
+                if (this.InvokedWithDebugFlag)
+                {
+                    powerShell.AddParameter("Debug", true);
+                }
+
                 var result = powerShell.Invoke();
                 return result;
             }


### PR DESCRIPTION
When creating a query with New-RscQuery and calling it with Invoke() , any -Debug or -Verbose parameter passed to the cmdlet is lost when reaching the Invoke()'s sub-session

JIRA Issues:
https://rubrik.atlassian.net/browse/SPARK-395332