### PR TITLE
Get-RscFileSet : fix arg assignment in nested query

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscFileset.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscFileset.cs
@@ -219,6 +219,13 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                         }
                         //PhysicalHost listQuery = new PhysicalHost();
 
+                        string physicalHostString = Query.PhysicalHost(nodeObj) ;
+                        physicalHostString = physicalHostString.Replace("typefilter:null","typeFilter: [LinuxFileset, WindowsFileset]");
+                        physicalHostString = physicalHostString.Replace("first:null","first: $first");
+                        physicalHostString = physicalHostString.Replace("after:null","after: $after");
+                        physicalHostString = physicalHostString.Replace("sortBy:null","sortBy: $sortBy");
+                        physicalHostString = physicalHostString.Replace("sortOrder:null","sortOrder: $sortOrder");
+                        physicalHostString = physicalHostString.Replace("filter:null","filter: $filter");
                         string listQueryString = $"query PhysicalHostQuery(" +
                             $"$fid: UUID!, " +
                             $"$first: Int, " +
@@ -227,17 +234,10 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                             $"$sortOrder: SortOrder, " +
                             $"$filter: [Filter!]" +
                             $"){{\n" +
-                            $"{Query.PhysicalHost(nodeObj)}" +
+                            $"{physicalHostString}" +
                             $"\n}}";
 
-                        listQueryString = listQueryString.Replace("physicalChildConnection",
-                            $"physicalChildConnection(" +
-                            $"typeFilter: [LinuxFileset, WindowsFileset], " +
-                            $"first: $first, " +
-                            $"after: $after, " +
-                            $"sortBy: $sortBy, " +
-                            $"sortOrder: $sortOrder, " +
-                            $"filter: $filter)");
+
 
 
                         //Initialize the variable set

--- a/Tests/e2e/Get-RscFileset.Tests.ps1
+++ b/Tests/e2e/Get-RscFileset.Tests.ps1
@@ -6,8 +6,6 @@ BeforeAll {
     . "$PSScriptRoot\..\E2eTestInit.ps1"
 }
 
-# TODO: SPARK-225906 fix this test
-return
 
 Describe -Name 'Get-RscFileset' -Tag 'Public' -Fixture{
     #Fileset by  FilesetId tests
@@ -18,6 +16,25 @@ Describe -Name 'Get-RscFileset' -Tag 'Public' -Fixture{
         }
     }
 
+    Context -Name "Call with HostId" {
+
+        It -Name "First 3 Windows Hosts from Get-RscHost" -Test {
+            $hosts = Get-RscHost -OsType Windows -First 3
+            # Bypass the test if there are no Windows hosts
+            if ($hosts.Count -eq 0) {
+                Skip "No Windows hosts found"
+            }
+            # for each host, get the filesets
+            $hosts | ForEach-Object {
+                $hostId = $_.Id
+                Get-RscFileset -HostId $hostId
+            }
+        }
+    }
+
+    # TODO: SPARK-225906 fix this test
+    return
+
     #Query tests
     Context -Name 'Query ParameterSet Validation' {
 
@@ -26,6 +43,7 @@ Describe -Name 'Get-RscFileset' -Tag 'Public' -Fixture{
             { New-Object PSObject -Property @{"Id"="0058bb59-adc4-598e-972a-ecd702624c7a"} | Get-RscFileset } | 
                 Should -Not -Throw
         }
+
 
         It -Name 'Parameter HostId(alias: Id) cannot be $null' -Test {
             { Get-RscFileset -HostId $null} |


### PR DESCRIPTION
Implementation in Get-RscFileSet does not properly fill in the nested query about Host Ids.