### PR TITLE
Change Get-RscVmwareVm -Name to return partial name matches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Fixes:
 
 Breaking Changes:
 
+- Get-RscVmwareVm : The `-Name` parameter now returns all VMs that partially match the specified `-Name` value, aligning with standard PowerShell conventions. Use the new `-ExactName` parameter to match the exact `-Name` value. e.g. `Get-RscVmwareVm -Name MyExactVmName -ExactName`
+
 ## Version 1.9
 
 Fixes:

--- a/Toolkit/Public/Get-RscVmwareVm.ps1
+++ b/Toolkit/Public/Get-RscVmwareVm.ps1
@@ -47,6 +47,11 @@ function Get-RscVmwareVm {
             Mandatory = $false,
             ParameterSetName = "Name"
         )]
+        [switch]$ExactName = $false,
+        [Parameter(
+            Mandatory = $false,
+            ParameterSetName = "Name"
+        )]
         [switch]$Relic,
         [Parameter(
             Mandatory = $false,
@@ -102,9 +107,12 @@ function Get-RscVmwareVm {
                     $name.Replace("*",'')
                     $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::REGEX
                     $nameFilter.texts = $Name.Replace("*",'')
-                } else {
+                } elseif ($ExactName){
                     $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::NAME_EXACT_MATCH
                     $nameFilter.texts = $Name
+                } else {
+                    $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::NAME
+                    $nameFilter.texts = $Name                    
                 }
                 $query.var.filter += $nameFilter
             }


### PR DESCRIPTION
For Get-RscVmwareVm, the `-Name` parameter returns all VMs that partially match the specified `-Name` value, aligning with standard PowerShell conventions. Use the new `-ExactName` parameter to match the exact `-Name` value. e.g. `Get-RscVmwareVm -Name MyExactVmName -ExactName`