### PR TITLE
Get-RscNasSystem: Remove forced requirement of -id

### DIFF
--- a/Toolkit/Public/Get-RscNasSystem.ps1
+++ b/Toolkit/Public/Get-RscNasSystem.ps1
@@ -15,6 +15,9 @@ function Get-RscNasSystem {
     .PARAMETER Id
     The Rubrik UUID of the Nas System object.
 
+    .PARAMETER Name
+    The name of the NAS system to filter on.
+
     .PARAMETER First
     The number of NAS systems to retrieve in one query.
 
@@ -22,33 +25,49 @@ function Get-RscNasSystem {
     Instead of running the command, the query object is returned.
 
     .EXAMPLE
-    Get details of NAS system with id="72859a28-6276-555a-9a66-d93fe99d2751"
-    Get-RscNasSystem "72859a28-6276-555a-9a66-d93fe99d2751"
+    Retrieve list of NAS systems.
+    Get-RscNasSystem
+        or 
+    Get-RscNasSystem -List
+    
+    .EXAMPLE
+    Retrieve all NAS systems with the name containing "foo".
+    Get-RscNasSystem -Name "foo"
+        or
+    Get-RscNasSystem "foo"
 
     .EXAMPLE
-    Retrieve list of NAS systems.
-    Get-RscNasSystem -First 2
+    Get details of NAS system with id="72859a28-6276-555a-9a66-d93fe99d2751"
+    Get-RscNasSystem -Id "72859a28-6276-555a-9a66-d93fe99d2751"
     #>
 
     [CmdletBinding(
-        DefaultParameterSetName = "Id"
+        DefaultParameterSetName = "List"
     )]
     Param(
-        # The UUID of the object representing the NAS system.
+        # The name of the NAS system to filter on.
         [Parameter(
-            ParameterSetName = "Id",
-            Mandatory = $true,
+            ParameterSetName = "Name",
+            Mandatory = $false,
             Position = 0
         )]
         [ValidateNotNullOrEmpty()]
-        [String]$Id,
+        [String]$Name,
 
-        # The number of NAS systems to retrieve in one query.
+        # The UUID of the object representing the NAS system.
+        [Parameter(
+            ParameterSetName = "Id",
+            Mandatory = $false
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String]$Id,
+        
+        # Retrieve list of NAS systems.
         [Parameter(
             ParameterSetName = "List",
             Mandatory = $false
         )]
-        [Int]$First = 50,
+        [Switch]$List,
 
         # Should Cmdlet return the query object instead of running it
         [Parameter(Mandatory = $false)]
@@ -67,9 +86,18 @@ function Get-RscNasSystem {
 
                 $query.Var.Fid = $Id
             }
+
+            "Name" {
+                $query = New-RscQueryNas -Operation Systems
+                $query.Field.Nodes[0].VendorType = "FETCH"
+                $InputObj = New-Object -TypeName RubrikSecurityCloud.Types.Filter
+                $InputObj.Field = "Name"
+                $InputObj.Texts = @($Name)
+                $query.Var.Filter = @($InputObj)
+            }
+
             "List" {
                 $query = New-RscQueryNas -Operation Systems
-                
                 $query.Field.Nodes[0].VendorType = "FETCH"
             }
         }
@@ -80,7 +108,7 @@ function Get-RscNasSystem {
 
         $result = Invoke-Rsc -Query $query
 
-        if ($PSCmdlet.ParameterSetName -eq "List") {
+        if ($PSCmdlet.ParameterSetName -eq "Name" -or $PSCmdlet.ParameterSetName -eq "List") {
             $result = $result.Nodes
         }
 

--- a/Toolkit/Tests/e2e/Get-RscNasSystem.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscNasSystem.Tests.ps1
@@ -1,0 +1,48 @@
+BeforeAll {
+    . "$PSScriptRoot\..\E2eTestInit.ps1"
+
+    # variables shared among tests
+    $Global:data = @{
+        nasSystems = $null
+    }
+}
+
+Describe -Name 'Get-RscNasSystem Tests' -Tag 'Public' -Fixture {
+
+    It -Name 'retrieves NAS-Systems' -Test {
+        $data.nasSystems = Get-RscNasSystem
+        Write-Host "data.nasSystems.count = $($data.nasSystems.count)"
+        $data.nasSystems | Should -Not -BeNullOrEmpty
+    }
+
+    Context -Name 'NasSystems Count > 0' {
+        BeforeEach {
+            # Skip the tests if empty NAS-Systems list 
+            if ($data.nasSystems.Count -le 0) {
+                Set-ItResult -Skipped -Because "At least 1 NAS-System is needed"
+                return
+            }
+        }
+
+        It -Name 'retrieves single NAS-System by Id' -Test {
+            $nasSystem0 = Get-RscNasSystem -Id $data.nasSystems[0].id
+            $nasSystem0.name | Should -Be $data.nasSystems[0].name
+            $nasSystem0.id | Should -Be $data.nasSystems[0].id
+        }
+
+        It -Name 'retrieves single NAS-System by Name' -Test {
+            $nasSystemsWithGivenName = Get-RscNasSystem -Name $data.nasSystems[0].name
+            $nasSystemsWithGivenName.Count | Should -BeGreaterThan 0
+            # One of the NAS-Systems in the list should have an id of $data.nasSystems[0].id
+            $match = $false
+            foreach ($nasSystem in $nasSystemsWithGivenName) {
+                if ($nasSystem.id -eq $data.nasSystems[0].id) {
+                    $match = $true
+                    break
+                }
+            }
+            $match | Should -Be $true
+        }
+    }
+
+}


### PR DESCRIPTION
# Summary:
The updated Get-RscNasSystem command will have
following functionality.

1. Get-RscNasSystem should return all NAS systems from the API. (Max Page size is 50)
2. Get-RscNasSystem -id "12345..." should return the NAS system with the specified ID.
3. Get-RscNasSystem -name "foo" should filter on NAS systems with the name of “foo” (Max Page size is 50)
4. Get-RscNasSystem -first 3 should return first 3 NAS systems
5. Get-RscNasSystem -name “foo” -first 3 should return first 3 NAS systems with name “foo”

# Test Plan:
Conducted manual testing by invoking Get-RscNasSystem for various scenarios.

Testing Doc: [link](https://docs.google.com/document/d/1ahwnPIp24BM5np4eSIa2Gj0Ewnma3gdTRtDLSQySsKM/edit?tab=t.0)

# JIRA:
SPARK-439652

# Revert Plan:
NA