### PR TITLE
Get-RscNasShare Filtering Updates

### DIFF
--- a/Toolkit/Public/Get-RscNasSystem.ps1
+++ b/Toolkit/Public/Get-RscNasSystem.ps1
@@ -18,8 +18,8 @@ function Get-RscNasSystem {
     .PARAMETER Name
     The name of the NAS system to filter on.
 
-    .PARAMETER First
-    The number of NAS systems to retrieve in one query.
+    .PARAMETER List
+    Switch to list all NAS systems.
 
     .PARAMETER AsQuery
     Instead of running the command, the query object is returned.

--- a/Toolkit/Tests/e2e/Get-RscNasShare.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscNasShare.Tests.ps1
@@ -1,0 +1,74 @@
+BeforeAll {
+    . "$PSScriptRoot\..\E2eTestInit.ps1"
+
+    # variables shared among tests
+    $Global:data = @{
+        nasShares = $null
+    }
+
+    $Global:data = @{
+        nasSystems = $null
+    }
+}
+
+Describe -Name 'Get-RscNasShare Tests' -Tag 'Public' -Fixture {
+
+    It -Name 'retrieves NAS-Shares' -Test {
+        $data.nasShares = Get-RscNasShare
+        Write-Host "NasShares Count = $($data.nasShares.count)"
+        $data.nasShares | Should -Not -BeNullOrEmpty
+
+        $data.nasSystems = Get-RscNasSystem
+        Write-Host "NasSystems Count = $($data.nasSystems.count)"
+        $data.nasSystems | Should -Not -BeNullOrEmpty
+    }
+
+    Context -Name 'NasShares Count > 0' {
+        BeforeEach {
+            # Skip the tests if empty NAS-Systems list 
+            if ($data.nasShares.Count -le 0) {
+                Set-ItResult -Skipped -Because "At least 1 NAS-Share is needed"
+                return
+            }
+        }
+
+        It -Name 'retrieves single NAS-Share by Id' -Test {
+            $nasShareWithGivenId = Get-RscNasShare -Id $data.nasShares[0].id
+            $nasShareWithGivenId.name | Should -Be $data.nasShares[0].name
+            $nasShareWithGivenId.id | Should -Be $data.nasShares[0].id
+        }
+
+        It -Name 'retrieves single NAS-Share by Name' -Test {
+            $nasSharesWithGivenName = Get-RscNasShare -Name $data.nasShares[0].name
+            $nasSharesWithGivenName.Count | Should -BeGreaterThan 0
+            # One of the NAS-Share in the list should have an id of $data.nasShares[0].id
+            $match = $false
+            foreach ($nasShare in $nasSharesWithGivenName) {
+                if ($nasShare.id -eq $data.nasShares[0].id) {
+                    $match = $true
+                    break
+                }
+            }
+            $match | Should -Be $true
+        }
+
+        It -Name 'retrieves single NAS-System by Id' -Test {
+            $nasSystemId = $data.nasSystems[0].id
+            $nasSystemName = $data.nasSystems[0].name
+            $nasSystemWithGivenName = Get-RscNasSystem -Id $nasSystemId
+            $nasSystemWithGivenName.name | Should -Be $nasSystemName
+            $nasSystemWithGivenName.id | Should -Be $nasSystemId
+        
+            $nasSharesForGivenNasSystemQuery = $nasSystemWithGivenName | Get-RscNasShare -AsQuery
+            $nasSharesForGivenNasSystemQuery.Field.DescendantConnection.Nodes[0].NasSystem = New-Object -TypeName RubrikSecurityCloud.Types.NasSystem
+            $nasSharesForGivenNasSystemQuery.Field.DescendantConnection.Nodes[0].NasSystem.Id = "Fetch"
+            $result = $nasSharesForGivenNasSystemQuery.Invoke()
+            $nasSharesForGivenNasSystem = $result.DescendantConnection.Nodes
+
+            foreach ($nasShare in $nasSharesForGivenNasSystem) {
+                $nasShare.NasSystem.Id | Should -Be $nasSystemId
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary:
1. Running Get-RscNasShare should return all NAS shares from the API.
2. Running Get-RscNasShare -Id "12345..." should return the NAS share with the specified ID.
3. Running Get-RscNasShare -name "foo" should filter on NAS shares with the name of “foo”
4. Running Get-RscNasSystem -name "bar" | Get-RscNasShare should return all shares from the NAS system “foo”

-> Corrected Parameter Doc for Get-RscNasSystem

## Test Plan:
-> Writen e2e tests for the above scenarios
-> Manual Testing Performed: [doc-link](https://docs.google.com/document/d/1Yp4EbPx43Uhn4K9I9ldfLQOHW4dhdroys31x8vq5rkM/edit?tab=t.0)
## Jira:
SPARK-439654

## Revert Plan:
NA