### PR TITLE
fix: Get-RscVmwareVm missing [0] before cluster

### DIFF
--- a/Toolkit/Public/Get-RscVmwareVm.ps1
+++ b/Toolkit/Public/Get-RscVmwareVm.ps1
@@ -103,7 +103,7 @@ function Get-RscVmwareVm {
             #$query = New-RscQueryVsphereVm -Operation NewList -FieldProfile $inputProfile
             $query = New-RscQuery -GqlQuery vsphereVmNewConnection -FieldProfile $inputProfile
             $query.var.filter = @()
-            $query.Field.Nodes.Cluster = New-Object -TypeName RubrikSecurityCloud.Types.Cluster
+            $query.Field.Nodes[0].Cluster = New-Object -TypeName RubrikSecurityCloud.Types.Cluster
             $query.Field.Nodes[0].Cluster.name = "PIZZA"
             $query.Field.Nodes[0].Cluster.id = "PIZZA"
             $query.Field.Nodes[0].GuestOsName = "TACOS"

--- a/Toolkit/Tests/e2e/Get-RscVmwareVm.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscVmwareVm.Tests.ps1
@@ -7,10 +7,8 @@ BeforeAll {
     }
 }
 
-# TODO: Fix this test : replace -Skip with -Fixture
-# see https://rubrik.atlassian.net/browse/SPARK-462877
-Write-Warning "TODO: Get-RscVmwareVm Tests are skipped"
-Describe -Name 'Get-RscVmwareVm Tests' -Tag 'Public' -Skip {
+
+Describe -Name 'Get-RscVmwareVm Tests' -Tag 'Public' -Fixture {
 
     It -Name 'retrieves VMs' -Test {
         $data.vm = Get-RscVmwareVm


### PR DESCRIPTION
Missing `[0]` in field selection caused query execution to fail.