### PR TITLE
Fix GenerateDocs Issue for Pwsh Cmdlets

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/docs/GenerateDocs.ps1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/docs/GenerateDocs.ps1
@@ -71,13 +71,6 @@ foreach ($memberItem in $xml.doc.members.member){
         Write-Output("`nProcessing Cmdlet: " + $cmdletName);
         #Write-Output("Opening markdownd for $cmdletName")
 
-        # TODO: SPARK-410830 SDK Build fails in GenerateDocs.ps1
-        # see https://rubrik.atlassian.net/browse/SPARK-410830
-        if ($cmdletName -eq "New-RscMutationSyslog" -or $cmdletName -eq "New-RscQueryMisc" -or $cmdletName -eq "Get-RscSnapshot"){
-            Write-Warning("Skipping $cmdletName due to known issue SPARK-410830")
-            continue
-        }
-
         $mdFile = "tmp_help/$($cmdletName).md"
         $cmdletMarkdown = Get-Content -Path $mdFile -Raw -ErrorAction Stop
 
@@ -101,7 +94,10 @@ foreach ($memberItem in $xml.doc.members.member){
             for ($i = 0; $i -le $examples.count -1; $i++ ){            
                 $exampleText += "### Example $($i+1)"
                 $exampleText += "`n```````n"
-                $exampleText += $examples[$i].code
+                # Replace tabs with 4 spaces and remove the first leading space from each line
+                $modifiedCode = ($examples[$i].code -split "`n" | ForEach-Object { 
+                    $_ -replace "`t", "    " -replace '^\s', '' }) -join "`n"
+                $exampleText += $modifiedCode
                 $exampleText += "`n```````n"
                 $exampleText += "$($($examples[$i].'#text') -replace '\s+', ' ')`n`n"
             }
@@ -109,6 +105,10 @@ foreach ($memberItem in $xml.doc.members.member){
             $exampleText += "### Example 1"
             $exampleText += "`n```````n"
             $exampleText += $examples.code
+            # Replace tabs with 4 spaces and remove the first leading space from each line
+            $modifiedCode = ($examples.code -split "`n" | ForEach-Object { 
+                $_ -replace "`t", "    " -replace '^\s', '' }) -join "`n"
+            $exampleText += $modifiedCode
             $exampleText += "`n```````n"
             $exampleText += "$($($examples.'#text') -replace '\s+', ' ')`n`n"
         }


### PR DESCRIPTION
## Summary:


### Initial Generated markdown
**Note:** It includes `13 spaces` in the 
beginning of the codeblock and
 includes `tab`
![image](https://github.com/user-attachments/assets/48efb0da-f969-48dd-947f-737771db1a22)


### Markdown Format Issues
- PlatyPS don't allow tabs in
   markdown, also mentioned [here](https://github.com/PowerShell/platyPS/blob/c7cd89b1c59b366b935d8e80de36815be6c00eec/docs/developer/platyPS/platyPS.schema.md?plain=1#L11)
  - Replacing tab with 4 or 6 spaces is 
     working fine but giving issue with 
     2 spaces.
- More than 12 leading spaces in a line is creating issue
  - Original Code includes 13 spaces in the beginning. 
  - Tried with 12 and less (succeeding)
  - Tried With 13 and 14 (failing)
 
 ### Fix Done:     
Replaced tabs with 4 spaces and removed 
the first leading space from each line.

### Generated markdown post fix
![image](https://github.com/user-attachments/assets/ed3af1f4-69e1-4ada-bb0d-4b3c2d9b9841)


## Test Plan:
DotNet Build succeeded with successful 
docs generation.
![image](https://github.com/user-attachments/assets/da8b7217-35db-4a0c-8020-1084563b4e25)


## JIRA Issues:
SPARK-410830

## Revert Plan:
NA