### PR TITLE
Fix Set-RscSla e2e Test

### DIFF
--- a/Toolkit/Public/Set-RscSla.ps1
+++ b/Toolkit/Public/Set-RscSla.ps1
@@ -257,7 +257,7 @@ function Set-RscSla
         # The retention lock mode for the intended SLA Domain update.
         [Parameter()]
         [RubrikSecurityCloud.Types.RetentionLockMode]
-        $RetentionLockMode = [RubrikSecurityCloud.Types.RetentionLockMode]::NO_MODE,
+        $RetentionLockMode,
 
         # Archival specs for this SLA.
         [Parameter()]

--- a/Toolkit/Tests/e2e/Set-RscSla.Tests.ps1
+++ b/Toolkit/Tests/e2e/Set-RscSla.Tests.ps1
@@ -3,141 +3,101 @@ BeforeAll {
 
     # Variables shared among tests
     $Global:data = @{
-        slaList = $null
+        slaId = $null
+        slaName = $null
     }
 }
 
-# Skip tests for duplicated SLAs in dev/staging due to unique key constraint on SLA name.
-# Also, skip tests if slaName is a prefix of another, causing Get-RscSla to return multiple SLAs.
-function IsValidSla {
-    param (
-        [Parameter(Mandatory = $true)]
-        [string] $slaName
-    )
-
-    $slaList = Get-RscSla -Name $slaName
-    if ($slaList.Count -gt 1) {
-        Write-Host "Skipping SLA '$slaName' due to duplication or name bieng prefix of another SLA"
-        return $false
-    }
-
-    return $true
-}
-
-function Compare-ArchivalSpecs {
-    param (
-        [Array]$original,
-        [Array]$retrieved
-    )
-    if ($original.Count -ne $retrieved.Count) {
-        return $false
-    }
-
-    foreach ($originalSpec in $original) {
-        $match = $false
-        foreach ($retrievedSpec in $retrieved) {
-            $originalSpecJson = $originalSpec | ConvertTo-Json -Depth 10
-            $retrievedSpecJson = $retrievedSpec | ConvertTo-Json -Depth 10
-            if ($originalSpecJson -eq $retrievedSpecJson) {
-                $match = $true
-                break
-            }
-        }
-        
-        if (-not $match) {
-            return $false
-        }
-    }
-
-    return $true
-}
-
-# TODO: Fix this test : replace -Skip with -Fixture
-# see https://rubrik.atlassian.net/browse/SPARK-462879
-Write-Warning "TODO: Set-RscSla Tests are skipped"
-Describe -Name 'Set-RscSla Tests' -Tag 'Public' -Skip {
+Describe -Name 'Set-RscSla Tests' -Tag 'Public' -Fixture {
 
     Context -Name 'Set-RscSla should update only specified fields not others' {
         BeforeEach {
-            $data.slaList = Get-RscSla | Sort-Object -Property SnapshotScheduleLastUpdatedAt -Descending | Select-Object -First 20
-            if ($data.slaList.Count -le 0) {
-                Set-ItResult -Skipped -Because "At least 1 SLA is needed"
+            # Create a new SLA for testing
+            try {
+                $randomNumber = Get-Random -Minimum 1000 -Maximum 9999
+                $slaName = "test-pwsh-e2e-$randomNumber"
+                $description = "SLA created for PowerShell e2e testing."
+
+                Write-Host "Creating SLA with name: $slaName"
+
+                $query = New-RscMutationSla -Operation CreateGlobal
+                $query.Var.input = @{
+                    name = $slaName
+                    description = $description
+                    snapshotSchedule = @{
+                        hourly = @{
+                            basicSchedule = @{
+                                frequency = 1
+                                retention = 1
+                                retentionUnit = [RubrikSecurityCloud.Types.RetentionUnit]::HOURS
+                            }
+                        }
+                    }
+                    objectTypes = @(
+                        [RubrikSecurityCloud.Types.SlaObjectType]::VSPHERE_OBJECT_TYPE
+                    )
+                    isRetentionLockedSla = $false
+                }
+                $result = $query | Invoke-Rsc
+                $data.slaId = $result.Id
+                $data.slaName = $result.Name
+
+                Write-Host "Successfully created SLA with ID: $($Global:data.slaId) and Name: $($Global:data.slaName)"
+            }
+            catch {
+                Set-ItResult -Skipped -Because "Failed to create SLA for the test: $_"
                 return
             }
         }
 
-        It -Name 'Validates SLAs Update should not change unspecified fields' -Test {
-            Write-Host "Proceeding testing $($data.slaList.count) SLAs"
-            
-            foreach ($sla in $data.slaList) {
-                $slaName = $sla.Name
+        AfterEach {
+            # Delete the SLA created for testing
+            if ($data.slaId) {
+                Write-Host "Deleting SLA: $($Global:data.slaName)"
 
-                if (-not (IsValidSla -slaName $slaName)) {
-                    continue
-                }
+                $query = New-RscMutationSla -Operation DeleteGlobal
+                $query.Var.id = $data.slaId
+                $query | Invoke-Rsc
 
-                Write-Host "Starting test for SLA '$slaName' - Date Updated: $($sla.SnapshotScheduleLastUpdatedAt)"
+                Write-Host "Successfully deleted SLA: $($Global:data.slaName)"
 
-                # Currently on dev/staging env, there exists a lot of invalid SLAs, 
-                # which will cause the test to fail, hence logging the error 
-                # and skipping the test. Here we are testing if Set-RscSla operation 
-                # is sucessful then it should not change any fields.
-                try {
-                    # Perform the update without changing any fields
-                    Set-RscSla -Sla $sla
-                } catch {
-                    Write-Host "Test Name: $($sla.Name), Test ID: $($sla.Id), Error: $($_.Exception.Message)"
-                    continue
-                }
-
-                $retrievedSla = Get-RscSla -Name $sla.Name
-    
-                # StateVersion will be updated by one after every update
-                $sla.stateVersion | Should -Be ($retrievedSla.stateVersion - 1)
-
-                # Clear the stateVersion since they already been checked
-                $sla.stateVersion = $null
-                $retrievedSla.stateVersion = $null
-
-                # Ignore comparing `storageSetting.Id` field for 
-                # archivalSpec, as it gets change every time update is performed
-                if ($sla.archivalSpecs -ne $null) {
-                    foreach ($spec in $sla.archivalSpecs) {
-                        if ($spec.storageSetting -ne $null) {
-                            $spec.storageSetting.Id = $null
-                        }
-                    }
-                }
-
-                if ($retrievedSla.archivalSpecs -ne $null) {
-                    foreach ($spec in $retrievedSla.archivalSpecs) {
-                        if ($spec.storageSetting -ne $null) {
-                            $spec.storageSetting.Id = $null
-                        }
-                    }
-                }
-
-                # archivalSepcs are not compared directly as they are arrays of objects
-                # and can come in any order, hence comparing them separately
-                $archivalSpecsMatch = $true
-                if ($sla.archivalSpecs -ne $null -or $retrievedSla.archivalSpecs -ne $null) {
-                    $archivalSpecsMatch = Compare-ArchivalSpecs -original $sla.archivalSpecs -retrieved $retrievedSla.archivalSpecs
-                }
-
-                $archivalSpecsMatch | Should -Be $true
-                
-                # Clear the archivalSpecs since they already been checked
-                $sla.archivalSpecs = $null
-                $retrievedSla.archivalSpecs = $null
-                
-                # Convert the original & retrieved SLA object to JSON for comparison,
-                # and compare the JSON strings
-                $originalJson = $sla | ConvertTo-Json -Depth 10
-                $retrievedJson = $retrievedSla | ConvertTo-Json -Depth 10
-                $originalJson | Should -Be $retrievedJson
-
-                Write-Host "Completed test for SLA '$slaName'"
+                $data.slaId = $null
+                $data.slaName = $null
             }
+        }
+        
+
+        It -Name 'Validates SLAs Update should not change unspecified fields' -Test {
+            Write-Host "Starting test for SLA '$($data.slaName)'"
+            $sla = Get-RscSla -Name $data.slaName
+            $updatedDescription = $sla.description + " Updated"
+
+            try {
+                Set-RscSla -Sla $sla -Description $updatedDescription
+            } catch {
+                Write-Host "Updating Sla '$($data.slaName)' failed with error: $($_.Exception.Message)"
+                return
+            }
+
+            $retrievedSla = Get-RscSla -Name $sla.Name
+            
+            $retrievedSla.description | Should -Be $updatedDescription
+
+            # StateVersion will be updated by one after every update
+            $sla.stateVersion | Should -Be ($retrievedSla.stateVersion - 1)
+
+            # Clear the stateVersion & description since they already been checked
+            $sla.stateVersion = $null
+            $retrievedSla.stateVersion = $null
+            $sla.description = $null
+            $retrievedSla.description = $null
+
+            $originalJson = $sla | ConvertTo-Json -Depth 10
+            $retrievedJson = $retrievedSla | ConvertTo-Json -Depth 10
+
+            $originalJson | Should -Be $retrievedJson
+
+            Write-Host "Completed test for SLA '$($data.slaName)'"
         }
     }
 }


### PR DESCRIPTION
## Summary:
Previously, our tests used existing SLAs 
from the testing environment, which led
 to unpredictable results. Now, this PR 
changes things up by creating a new SLA, 
running the test scenarios, 
and then cleaning it up afterwards. 
This way, our tests are more reliable 
with predictable behaviour.

## Test Plan:
- Test completed successfully
<img width="458" alt="image" src="https://github.com/user-attachments/assets/57eb9ca4-a433-4f23-b194-5d075421178a" />

## JIRA Issues:
[SPARK-462879](https://rubrik.atlassian.net/browse/SPARK-462879)

## Revert Plan:
NA