### PR TITLE
Fix Get-RscNasShare e2e test

### DIFF
--- a/Toolkit/Tests/e2e/Get-RscNasShare.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscNasShare.Tests.ps1
@@ -11,24 +11,19 @@ BeforeAll {
     }
 }
 
-# TODO: Fix this test: replace -Skip with -Fixture
-# see https://rubrik.atlassian.net/browse/SPARK-462873
-Write-Warning "TODO: Get-RscNasShare Tests are skipped"
-Describe -Name 'Get-RscNasShare Tests' -Tag 'Public' -Skip {
+Describe -Name 'Get-RscNasShare Tests' -Tag 'Public' -Fixture {
 
     It -Name 'retrieves NAS-Shares' -Test {
         $data.nasShares = Get-RscNasShare
-        Write-Host "NasShares Count = $($data.nasShares.count)"
         $data.nasShares | Should -Not -BeNullOrEmpty
 
         $data.nasSystems = Get-RscNasSystem
-        Write-Host "NasSystems Count = $($data.nasSystems.count)"
         $data.nasSystems | Should -Not -BeNullOrEmpty
     }
 
     Context -Name 'NasShares Count > 0' {
         BeforeEach {
-            # Skip the tests if empty NAS-Systems list 
+            # Skip the tests if empty NAS-Shares list 
             if ($data.nasShares.Count -le 0) {
                 Set-ItResult -Skipped -Because "At least 1 NAS-Share is needed"
                 return
@@ -36,17 +31,17 @@ Describe -Name 'Get-RscNasShare Tests' -Tag 'Public' -Skip {
         }
 
         It -Name 'retrieves single NAS-Share by Id' -Test {
-            $nasShareWithGivenId = Get-RscNasShare -Id $data.nasShares[0].id
-            $nasShareWithGivenId.name | Should -Be $data.nasShares[0].name
-            $nasShareWithGivenId.id | Should -Be $data.nasShares[0].id
+            $nasShareById = Get-RscNasShare -Id $data.nasShares[0].id
+            $nasShareById.name | Should -Be $data.nasShares[0].name
+            $nasShareById.id | Should -Be $data.nasShares[0].id
         }
 
         It -Name 'retrieves single NAS-Share by Name' -Test {
-            $nasSharesWithGivenName = Get-RscNasShare -Name $data.nasShares[0].name
-            $nasSharesWithGivenName.Count | Should -BeGreaterThan 0
+            $nasSharesByName = Get-RscNasShare -Name $data.nasShares[0].name
+            $nasSharesByName.Count | Should -BeGreaterThan 0
             # One of the NAS-Share in the list should have an id of $data.nasShares[0].id
             $match = $false
-            foreach ($nasShare in $nasSharesWithGivenName) {
+            foreach ($nasShare in $nasSharesByName) {
                 if ($nasShare.id -eq $data.nasShares[0].id) {
                     $match = $true
                     break
@@ -55,20 +50,23 @@ Describe -Name 'Get-RscNasShare Tests' -Tag 'Public' -Skip {
             $match | Should -Be $true
         }
 
-        It -Name 'retrieves single NAS-System by Id' -Test {
+        It -Name 'retrieves NAS-Shares associated with the specified NAS-System' -Test {
             $nasSystemId = $data.nasSystems[0].id
             $nasSystemName = $data.nasSystems[0].name
-            $nasSystemWithGivenName = Get-RscNasSystem -Id $nasSystemId
-            $nasSystemWithGivenName.name | Should -Be $nasSystemName
-            $nasSystemWithGivenName.id | Should -Be $nasSystemId
+            $nasSystemById = Get-RscNasSystem -Id $nasSystemId
+            $nasSystemById.name | Should -Be $nasSystemName
+            $nasSystemById.id | Should -Be $nasSystemId
         
-            $nasSharesForGivenNasSystemQuery = $nasSystemWithGivenName | Get-RscNasShare -AsQuery
-            $nasSharesForGivenNasSystemQuery.Field.DescendantConnection.Nodes[0].NasSystem = New-Object -TypeName RubrikSecurityCloud.Types.NasSystem
-            $nasSharesForGivenNasSystemQuery.Field.DescendantConnection.Nodes[0].NasSystem.Id = "Fetch"
-            $result = $nasSharesForGivenNasSystemQuery.Invoke()
-            $nasSharesForGivenNasSystem = $result.DescendantConnection.Nodes
-
-            foreach ($nasShare in $nasSharesForGivenNasSystem) {
+            $nasSharesByNasSystemQuery = $nasSystemById | Get-RscNasShare -AsQuery
+            $nasSharesByNasSystemQuery.Field.DescendantConnection.Nodes[0].NasSystem = New-Object -TypeName RubrikSecurityCloud.Types.NasSystem
+            $nasSharesByNasSystemQuery.Field.DescendantConnection.Nodes[0].NasSystem.Id = "Fetch"
+            $result = $nasSharesByNasSystemQuery.Invoke()
+            $nasSharesByNasSystem = $result.DescendantConnection.Nodes
+            foreach ($nasShare in $nasSharesByNasSystem) {
+                # Skip the NAS-Share if it's invalid
+                if ($null -eq $nasShare.Id) {
+                    continue
+                }
                 $nasShare.NasSystem.Id | Should -Be $nasSystemId
             }
         }


### PR DESCRIPTION
## Summary:
- Earlier `nasShares` query wansn't exposed publically, probably while
jira creation, schema for rubrik-inc
pwsh repo wasn't updated with latest
one, hence it failed with jira
tagged error.

- Verfied that `New-RscQueryNas.cs` now contains `Shares` subcommand.

- Also noted, UT testing all NasShares for a given NasSystem, failed because of
comparison with invalid NasShares
(with $null ids). Have
updated the test to ignore
comparison of such NasShares.

## Test Plan:
Test Ran successfully
<img width="430" alt="image" src="https://github.com/user-attachments/assets/69aa4bc9-9a70-40e5-aa64-7434dbc63930" />

## JIRA Issues:
[SPARK-462873](https://rubrik.atlassian.net/browse/SPARK-462873)

## Revert Plan:
NA