### PR TITLE
Upgrade .Net Module Configs to remove warnings

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/RubrikSecurityCloud.Client.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/RubrikSecurityCloud.Client.csproj
@@ -22,6 +22,6 @@
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
@@ -9,7 +9,7 @@ try {
     # Determine the module directory based on the PowerShell edition
     If ($PSVersionTable.PSEdition -eq "Desktop") {
        # Write-Host "`nLoading Rubrik Security Cloud PowerShell Module (WindowsPowerShell)...`n"
-        $moduleDir = Join-Path -Path $PSScriptRoot -ChildPath "net461"
+        $moduleDir = Join-Path -Path $PSScriptRoot -ChildPath "net462"
 
         # Load the specific versions of required assemblies
         $unsafeAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.Runtime.CompilerServices.Unsafe.dll'

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>

--- a/Utils/_Build-RscSdk.ps1
+++ b/Utils/_Build-RscSdk.ps1
@@ -74,7 +74,7 @@ if ($LASTEXITCODE -ne 0 ) {
 Copy-Item -Recurse -Force $ProjectOutputDir $OutputDir
 $helpXmlPath = "$OutputDir\net6.0\RubrikSecurityCloud.PowerShell.dll-Help.xml"
 if (Test-Path $helpXmlPath) {
-    Copy-Item $helpXmlPath $OutputDir\net461\
+    Copy-Item $helpXmlPath $OutputDir\net462\
 } else {
     Write-Warning "Documentation XML file not found. Skipping copy."
 }


### PR DESCRIPTION
## Summary:
This PR does following
- Removes `CVE-2024-43485` vulnerability from the RubrikSecurityCloud Client module by
updating the System.Text.JSON package to
version `8.0.5`.

- Upgrades the target runtime of the RubrikSecurityCloud PowerShell module to `net462`

## JIRA Issues:
[SPARK-473776](https://rubrik.atlassian.net/browse/SPARK-473776)
[SPARK-432214](https://rubrik.atlassian.net/browse/SPARK-432214)
[SPARK-473769](https://rubrik.atlassian.net/browse/SPARK-473769)

## Test Plan:
**`make` logs before changes**
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/113f89c3-d44b-4bb9-b18f-9a476166cba1" />

**`make` logs after changes**
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e7b543fd-70f5-4482-9242-d1e120f7dc7f" />


## Revert Plan:
NA