### PR TITLE
Revert pwsh runtime upgrade

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
@@ -9,7 +9,7 @@ try {
     # Determine the module directory based on the PowerShell edition
     If ($PSVersionTable.PSEdition -eq "Desktop") {
        # Write-Host "`nLoading Rubrik Security Cloud PowerShell Module (WindowsPowerShell)...`n"
-        $moduleDir = Join-Path -Path $PSScriptRoot -ChildPath "net462"
+        $moduleDir = Join-Path -Path $PSScriptRoot -ChildPath "net461"
 
         # Load the specific versions of required assemblies
         $unsafeAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.Runtime.CompilerServices.Unsafe.dll'

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>

--- a/Utils/_Build-RscSdk.ps1
+++ b/Utils/_Build-RscSdk.ps1
@@ -74,7 +74,7 @@ if ($LASTEXITCODE -ne 0 ) {
 Copy-Item -Recurse -Force $ProjectOutputDir $OutputDir
 $helpXmlPath = "$OutputDir\net6.0\RubrikSecurityCloud.PowerShell.dll-Help.xml"
 if (Test-Path $helpXmlPath) {
-    Copy-Item $helpXmlPath $OutputDir\net462\
+    Copy-Item $helpXmlPath $OutputDir\net461\
 } else {
     Write-Warning "Documentation XML file not found. Skipping copy."
 }


### PR DESCRIPTION
## Summary 
The PR reverts net461 upgrade to 
net462 done by [this](https://github.com/rubrikinc/rubrik-powershell-sdk/pull/175) PR, 
since it's breaking with `pwsh-5.1` 

## Test Plan 
By reverting target-version to net461, 
basic commands are succeeding. 
![image](https://github.com/user-attachments/assets/e212e46e-593a-4b12-989a-067da27ce1c7)

## JIRA
[SPARK-483375](https://rubrik.atlassian.net/browse/SPARK-483375)

