### PR TITLE
net481 toolkit scripts fixes

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
@@ -9,13 +9,14 @@ try {
     # Determine the module directory based on the PowerShell edition
     If ($PSVersionTable.PSEdition -eq "Desktop") {
        # Write-Host "`nLoading Rubrik Security Cloud PowerShell Module (WindowsPowerShell)...`n"
-        $moduleDir = Join-Path -Path $PSScriptRoot -ChildPath "net461"
+        $moduleDir = Join-Path -Path $PSScriptRoot -ChildPath "net481"
 
         # Load the specific versions of required assemblies
         $unsafeAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.Runtime.CompilerServices.Unsafe.dll'
         $vectorsAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.Numerics.Vectors.dll'
         $buffersAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.Buffers.dll'
         $annotationsAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.ComponentModel.Annotations.dll'
+        $textJsonAssemblyPath = Join-Path -Path $moduleDir -ChildPath 'System.Text.Json.dll'
         
         # Force loading the correct assembly versions
         # [System.Reflection.Assembly]::LoadFrom($unsafeAssemblyPath)
@@ -38,6 +39,10 @@ try {
             elseif ($e.Name -like 'System.ComponentModel.Annotations, *') {
                 # Write-Host "LoadModule.psm1: Redirecting $e.Name to the correct System.ComponentModel.Annotations assembly"
                 return [System.Reflection.Assembly]::LoadFrom($annotationsAssemblyPath)
+            }
+            elseif ($e.Name -like 'System.Text.Json, *') {
+                # Write-Host "LoadModule.psm1: Redirecting $e.Name to the correct System.ComponentModel.Annotations assembly"
+                return [System.Reflection.Assembly]::LoadFrom($textJsonAssemblyPath)
             }
         }
 

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net481</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>

--- a/Toolkit/Public/Get-RscNasShare.ps1
+++ b/Toolkit/Public/Get-RscNasShare.ps1
@@ -143,7 +143,8 @@ function Get-RscNasShare {
 
             $Field.DescendantConnection = New-Object -TypeName `
                 RubrikSecurityCloud.Types.NasShareDescendantTypeConnection
-            $Field.DescendantConnection.Nodes = @(InitializeDescendantConnectionNodes)
+            
+            $Field.DescendantConnection.Nodes = [RubrikSecurityCloud.Types.NasFileset[]](InitializeDescendantConnectionNodes)
 
             $Field.Cluster = New-Object -TypeName RubrikSecurityCloud.Types.Cluster
             InitializeCluster -ClusterField $Field.Cluster
@@ -171,7 +172,7 @@ function Get-RscNasShare {
                 $InputObj = New-Object -TypeName RubrikSecurityCloud.Types.Filter
                 $InputObj.Field = "Name"
                 $InputObj.Texts = @($Name)
-                $query.Var.Filter = @($InputObj)
+                $query.Var.Filter = [RubrikSecurityCloud.Types.Filter[]]@($InputObj)
                 
                 # Specify additional fields not in default field profile.
                 $query.Field.Nodes[0].HostAddress = "FETCH"
@@ -200,8 +201,7 @@ function Get-RscNasShare {
                 # Specify additional fields not in default field profile.
                 $query.Field.DescendantConnection = New-Object -TypeName `
                     RubrikSecurityCloud.Types.NasSystemDescendantTypeConnection
-                $query.Field.DescendantConnection.Nodes = @(New-Object -TypeName `
-                    RubrikSecurityCloud.Types.NasShare)
+                $query.Field.DescendantConnection.Nodes = [RubrikSecurityCloud.Types.NasShare[]]@(New-Object -TypeName RubrikSecurityCloud.Types.NasShare)
                 $query.Field.DescendantConnection.Nodes[0].Id = "FETCH"
                 $query.Field.DescendantConnection.Nodes[0].Name = "FETCH"
                 $query.Field.DescendantConnection.Nodes[0].IsStale = $true

--- a/Toolkit/Public/Get-RscOrganization.ps1
+++ b/Toolkit/Public/Get-RscOrganization.ps1
@@ -68,7 +68,7 @@ function Get-RscOrganization {
             $query.field.AllUrls = "FETCH"
             # "ClusterWithCapacityQuota" does not exist in the SDK
             # $query.Nodes[0].AllClusterCapacityQuotas = New-Object -TypeName RubrikSecurityCloud.Types.ClusterWithCapacityQuota
-            $query.field.CrossAccountCapabilities = [RubrikSecurityCloud.Types.CrossAccountCapability]::CROSS_ACCOUNT_CAPABILITY_UNSPECIFIED
+            $query.field.CrossAccountCapabilities = @([RubrikSecurityCloud.Types.CrossAccountCapability]::CROSS_ACCOUNT_CAPABILITY_UNSPECIFIED)
 
             $result = Invoke-Rsc -Query $query
             $result
@@ -106,7 +106,7 @@ function Get-RscOrganization {
             $query.field.Nodes[0].AllUrls = "FETCH"
             # "ClusterWithCapacityQuota" does not exist in the SDK
             # $query.Nodes[0].AllClusterCapacityQuotas = New-Object -TypeName RubrikSecurityCloud.Types.ClusterWithCapacityQuota
-            $query.field.Nodes[0].CrossAccountCapabilities = [RubrikSecurityCloud.Types.CrossAccountCapability]::CROSS_ACCOUNT_CAPABILITY_UNSPECIFIED
+            $query.field.Nodes[0].CrossAccountCapabilities = @([RubrikSecurityCloud.Types.CrossAccountCapability]::CROSS_ACCOUNT_CAPABILITY_UNSPECIFIED)
 
             $result = Invoke-Rsc -Query $query
             $result.nodes

--- a/Toolkit/Public/Get-RscSla.ps1
+++ b/Toolkit/Public/Get-RscSla.ps1
@@ -172,7 +172,7 @@ function Get-RscSla {
 
                 # frequencies: [RetentionUnit!]!
                 # Archives all snapshots taken with the specified frequency.
-                $query.field.getNext().ArchivalSpecs[0].frequencies = [RubrikSecurityCloud.Types.RetentionUnit]::DAYS
+                $query.field.getNext().ArchivalSpecs[0].frequencies = @([RubrikSecurityCloud.Types.RetentionUnit]::DAYS)
 
                 # archivalLocationToClusterMapping: [ArchivalLocationToClusterMapping!]!
                 # Mapping between archival location and Rubrik cluster.
@@ -244,7 +244,7 @@ function Get-RscSla {
 
                     # frequency: [RetentionUnit!]!
                     # Frequencies that are associated with this cascaded archival location.
-                    $query.field.getNext().ReplicationSpecsV2[0].cascadingArchivalSpecs[0].frequency = [RubrikSecurityCloud.Types.RetentionUnit]::DAYS
+                    $query.field.getNext().ReplicationSpecsV2[0].cascadingArchivalSpecs[0].frequency = @([RubrikSecurityCloud.Types.RetentionUnit]::DAYS)
 
                     # archivalLocation: Target
                     # Archival location for snapshot on target.
@@ -493,7 +493,7 @@ function Get-RscSla {
 
             # objectTypes: [SlaObjectType!]!
             # The object-types supported by the SLA Domain.
-            $query.field.getNext().objectTypes = [RubrikSecurityCloud.Types.SlaObjectType]::KUPR_OBJECT_TYPE
+            $query.field.getNext().objectTypes = @([RubrikSecurityCloud.Types.SlaObjectType]::KUPR_OBJECT_TYPE)
 
             # clusterUuid: String!
             # Rubrik cluster ID of the SLA Domain.
@@ -686,7 +686,7 @@ function Get-RscSla {
 
                 # frequencies: [RetentionUnit!]!
                 # Archives all snapshots taken with the specified frequency.
-                $query.field.nodes[$globalSlaReply].ArchivalSpecs[0].frequencies = [RubrikSecurityCloud.Types.RetentionUnit]::DAYS
+                $query.field.nodes[$globalSlaReply].ArchivalSpecs[0].frequencies = @([RubrikSecurityCloud.Types.RetentionUnit]::DAYS)
 
                 # archivalLocationToClusterMapping: [ArchivalLocationToClusterMapping!]!
                 # Mapping between archival location and Rubrik cluster.
@@ -758,7 +758,7 @@ function Get-RscSla {
 
                     # frequency: [RetentionUnit!]!
                     # Frequencies that are associated with this cascaded archival location.
-                    $query.field.nodes[$globalSlaReply].ReplicationSpecsV2[0].cascadingArchivalSpecs[0].frequency = [RubrikSecurityCloud.Types.RetentionUnit]::DAYS
+                    $query.field.nodes[$globalSlaReply].ReplicationSpecsV2[0].cascadingArchivalSpecs[0].frequency = @([RubrikSecurityCloud.Types.RetentionUnit]::DAYS)
 
                     # archivalLocation: Target
                     # Archival location for snapshot on target.
@@ -1007,7 +1007,7 @@ function Get-RscSla {
 
             # objectTypes: [SlaObjectType!]!
             # The object-types supported by the SLA Domain.
-            $query.field.nodes[$globalSlaReply].objectTypes = [RubrikSecurityCloud.Types.SlaObjectType]::KUPR_OBJECT_TYPE
+            $query.field.nodes[$globalSlaReply].objectTypes = @([RubrikSecurityCloud.Types.SlaObjectType]::KUPR_OBJECT_TYPE)
 
             # clusterUuid: String!
             # Rubrik cluster ID of the SLA Domain.

--- a/Toolkit/Tests/e2e/Get-RscNasShare.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscNasShare.Tests.ps1
@@ -37,7 +37,7 @@ Describe -Name 'Get-RscNasShare Tests' -Tag 'Public' -Fixture {
         }
 
         It -Name 'retrieves single NAS-Share by Name' -Test {
-            $nasSharesByName = Get-RscNasShare -Name $data.nasShares[0].name
+            $nasSharesByName = @(Get-RscNasShare -Name $data.nasShares[0].name)
             $nasSharesByName.Count | Should -BeGreaterThan 0
             # One of the NAS-Share in the list should have an id of $data.nasShares[0].id
             $match = $false

--- a/Toolkit/Tests/e2e/Get-RscNasSystem.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscNasSystem.Tests.ps1
@@ -31,7 +31,7 @@ Describe -Name 'Get-RscNasSystem Tests' -Tag 'Public' -Fixture {
         }
 
         It -Name 'retrieves single NAS-System by Name' -Test {
-            $nasSystemsWithGivenName = Get-RscNasSystem -Name $data.nasSystems[0].name
+            $nasSystemsWithGivenName = @(Get-RscNasSystem -Name $data.nasSystems[0].name)
             $nasSystemsWithGivenName.Count | Should -BeGreaterThan 0
             # One of the NAS-Systems in the list should have an id of $data.nasSystems[0].id
             $match = $false

--- a/Utils/_Build-RscSdk.ps1
+++ b/Utils/_Build-RscSdk.ps1
@@ -68,7 +68,7 @@ if ($LASTEXITCODE -ne 0 ) {
 Copy-Item -Recurse -Force $ProjectOutputDir $OutputDir
 $helpXmlPath = "$OutputDir\net6.0\RubrikSecurityCloud.PowerShell.dll-Help.xml"
 if (Test-Path $helpXmlPath) {
-    Copy-Item $helpXmlPath $OutputDir\net461\
+    Copy-Item $helpXmlPath $OutputDir\net481\
 } else {
     Write-Warning "Documentation XML file not found. Skipping copy."
 }


### PR DESCRIPTION
This PR contains following. 
- Upgrade of net461 to net481
- Since net481 doesn't detect 
   path of assembly `System.Text.Json 8.0.5` 
   in pwsh5, forcefully resolving it in `LoadModule.ps1`
- Fixes for toolkit scripts, 
failing in pwsh-5 due to recently 
discovered types-casting issues.

