### PR TITLE
Toolkit cmdlet fixes

### DIFF
--- a/Toolkit/Public/Get-RscArchivalLocation.ps1
+++ b/Toolkit/Public/Get-RscArchivalLocation.ps1
@@ -60,9 +60,10 @@ function Get-RscArchivalLocation {
             $query.Field.targetType = [RubrikSecurityCloud.Types.TargetType]::AWS
             $query.Field.connectionStatus = New-Object -TypeName RubrikSecurityCloud.Types.ArchivalGroupConnectionStatus
             $query.Field.connectionStatus.status = [RubrikSecurityCloud.Types.ConnectionStatusType]::CONNECTED
-            $query.Field.tieringStatus = [RubrikSecurityCloud.Types.ArchivalGroupTieringStatus]::UNKNOWN_ARCHIVAL_GROUP_TIERING_STATUS
-            $query.Field.targets[0] = New-Object -TypeName RubrikSecurityCloud.Types.RubrikManagedAwsTarget
-            $query.Field.targets += New-Object -TypeName RubrikSecurityCloud.Types.RubrikManagedAzureTarget
+            $query.Field.tieringStatus = @([RubrikSecurityCloud.Types.ArchivalGroupTieringStatus]::UNKNOWN_ARCHIVAL_GROUP_TIERING_STATUS)
+
+            $query.Field.targets = New-Object -TypeName RubrikSecurityCloud.Types.RubrikManagedAwsTarget
+            $query.Field.targets.add((New-Object -TypeName RubrikSecurityCloud.Types.RubrikManagedAzureTarget))
             #$query.Field.targets[0].cluster = New-Object -TypeName RubrikSecurityCloud.Types.Cluster
             #$query.Field.targets[0].cluster.name = "FETCH"
             #$query.Field.targets[0].cluster.id = "FETCH"
@@ -94,7 +95,7 @@ function Get-RscArchivalLocation {
             if ($Name) {
                 $query.var.filter += New-Object -TypeName RubrikSecurityCloud.Types.TargetMappingFilterInput
                 $query.var.filter[1].field = [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::NAME
-                $query.var.filter[1].name = $Name
+                $query.var.filter[1].text = $Name
             }
 
             $query.Field[0].id = "FETCH"
@@ -103,7 +104,7 @@ function Get-RscArchivalLocation {
             $query.Field[0].targetType = [RubrikSecurityCloud.Types.TargetType]::AWS
             $query.Field[0].connectionStatus = New-Object -TypeName RubrikSecurityCloud.Types.ArchivalGroupConnectionStatus
             $query.Field[0].connectionStatus.status = [RubrikSecurityCloud.Types.ConnectionStatusType]::CONNECTED
-            $query.Field[0].tieringStatus = [RubrikSecurityCloud.Types.ArchivalGroupTieringStatus]::UNKNOWN_ARCHIVAL_GROUP_TIERING_STATUS
+            $query.Field[0].tieringStatus = @([RubrikSecurityCloud.Types.ArchivalGroupTieringStatus]::UNKNOWN_ARCHIVAL_GROUP_TIERING_STATUS)
 
             $query.Field[0].targets = New-Object -TypeName RubrikSecurityCloud.Types.RubrikManagedAwsTarget
             $query.Field[0].targets.add((New-Object -TypeName RubrikSecurityCloud.Types.RubrikManagedAzureTarget))

--- a/Toolkit/Public/Get-RscAzureNativeVm.ps1
+++ b/Toolkit/Public/Get-RscAzureNativeVm.ps1
@@ -51,25 +51,22 @@ function Get-RscAzureNativeVm {
        # The query is different for getting a single object by ID.
         if ($Id) {
             $query = New-RscQuery -GqlQuery azureNativeVirtualMachine
-            $query.var.filter = @()
-            $query.Var.fid = $Id
+            $query.Var.azureVirtualMachineRubrikId = $Id
 
             $result = Invoke-Rsc -Query $query
             $result
         } else {
             $query = New-RscQuery -GqlQuery azureNativeVirtualMachines
-            $query.var.filter = New-Object -TypeName RubrikSecurityCloud.Types.AzureNativeVirtualMachineFilters
+            $query.var.virtualMachineFilters = (New-Object -TypeName RubrikSecurityCloud.Types.AzureNativeVirtualMachineFilters)
 
-            if ($NameSubstring) {
-                $query.var.filter.nameSubstringFilter = New-Object -TypeName RubrikSecurityCloud.Types.NameSubstringFilter
-                $query.var.filter.nameSubstringFilter.NameSubstring = $NameSubstring
+            if ($NameSubstring) {          
+                $query.var.virtualMachineFilters.nameSubstringFilter = New-Object -TypeName RubrikSecurityCloud.Types.NameSubstringFilter
+                $query.var.virtualMachineFilters.nameSubstringFilter.NameSubstring = $NameSubstring
             }
     
             if ($Sla) {
-                $slaFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
-                $slaFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::EFFECTIVE_SLA
-                $slaFilter.Texts = $Sla.id
-                $query.var.filter += $slaFilter
+                $query.var.virtualMachineFilters.effectiveSlaFilter =  (New-Object -TypeName RubrikSecurityCloud.Types.EffectiveSlaFilter)
+                $query.var.virtualMachineFilters.effectiveSlaFilter.effectiveSlaIds = @($Sla.id)
             }
 
             $result = Invoke-Rsc -Query $query

--- a/Toolkit/Public/Get-RscCloudNativeTagRule.ps1
+++ b/Toolkit/Public/Get-RscCloudNativeTagRule.ps1
@@ -30,11 +30,6 @@ function Get-RscCloudNativeTagRule {
     Param(
         [Parameter(
             Mandatory = $false,
-            ParameterSetName = "Id"
-        )]
-        [String]$Id,
-        [Parameter(
-            Mandatory = $false,
             ParameterSetName = "Name"
         )]
         [String]$Name,
@@ -53,16 +48,6 @@ function Get-RscCloudNativeTagRule {
     )
     
     Process {
-
-       # The query is different for getting a single object by ID.
-        if ($Id) {
-            $query = New-RscQuery -GqlQuery 
-            $query.var.filters = @()
-            $query.var.fid = $Id
-
-            $result = Invoke-Rsc -Query $query
-            $result
-        } else {
             $query = New-RscQuery -GqlQuery cloudNativeTagRules
             $query.field.tagRules = New-Object -TypeName RubrikSecurityCloud.Types.CloudNativeTagRule
             $query.field.tagRules[0].name = "FETCH"
@@ -72,7 +57,7 @@ function Get-RscCloudNativeTagRule {
             $query.field.tagRules[0].effectiveSla.id = "FETCH"
             $query.field.tagRules[0].objectType = [RubrikSecurityCloud.Types.ManagedObjectType]::AWS_NATIVE_EC2_INSTANCE
 
-            $query.var.filters = @()
+            $query.var.filter = @()
 
             if ($Name) {
                 $nameFilter = New-Object -TypeName RubrikSecurityCloud.Types.CloudNativeFilter 
@@ -92,12 +77,6 @@ function Get-RscCloudNativeTagRule {
 
             $result = Invoke-Rsc -Query $query
             $result.tagRules
-        }
-
-
-
-
-
     } 
 }
 

--- a/Toolkit/Public/Get-RscCluster.ps1
+++ b/Toolkit/Public/Get-RscCluster.ps1
@@ -142,7 +142,8 @@ function Get-RscCluster {
             }
             "Id" {
                 $query = New-RscQueryCluster -Operation List -RemoveField Nodes.isHealthy -FieldProfile $fieldProfile
-                $query.Var.clusterUuid = $Id
+                $query.Var.filter = New-Object -TypeName RubrikSecurityCloud.Types.ClusterFilterInput
+                $query.Var.filter.id = $Id
             }
             "Name" {
                 $query = New-RscQueryCluster -Operation List -RemoveField Nodes.isHealthy -FieldProfile $fieldProfile

--- a/Toolkit/Public/Get-RscDb2Instance.ps1
+++ b/Toolkit/Public/Get-RscDb2Instance.ps1
@@ -58,7 +58,7 @@ function Get-RscDb2Instance {
         if ($Id) {
             $query = New-RscQuery -GqlQuery db2Instance
             $query.var.filter = @()
-            $query.Var.fid = $Id
+            $query.Var.id = $Id
 
             $result = Invoke-Rsc -Query $query
             $result

--- a/Toolkit/Public/Get-RscManagedVolume.ps1
+++ b/Toolkit/Public/Get-RscManagedVolume.ps1
@@ -65,28 +65,26 @@ function Get-RscManagedVolume {
         if ( $Detail -eq $true ) {
             $fieldProfile = "DETAIL"
         }
+
+        $query = New-RscQueryManagedVolume -Operation ManagedVolumes -FieldProfile $fieldProfile 
+        $query.Var.filter = @()
+
         #region Create Query
-        switch ( $PSCmdlet.ParameterSetName){
-            "List" {
-                $query = New-RscQueryManagedVolume -Operation ManagedVolumes -FieldProfile $fieldProfile 
-            }
-            "Name"{
-                $query = New-RscQueryManagedVolume -Operation ManagedVolumes -FieldProfile $fieldProfile 
-                $query.Var.filter = @()
-                $nameFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
-                $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::NAME_EXACT_MATCH
-                $nameFilter.texts = $Name
-                $query.Var.filter += $nameFilter
-            }
+        if($Name) {
+            $nameFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
+            $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::NAME_EXACT_MATCH
+            $nameFilter.texts = $Name
+            $query.Var.filter += $nameFilter
         }
-        #endregion
-        if($PSBoundParameters.ContainsKey('clusterId')) {
+        if($RscCluster) {
             $clusterFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
             $clusterFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::CLUSTER_ID
             $clusterFilter.texts = $RscCluster.Id
             $query.Var.filter += $clusterFilter
         }
+        
+        #endregion
         $result = $query.Invoke()
         $result.Nodes
-    } 
-}
+    }
+} 

--- a/Toolkit/Public/Get-RscMssqlLiveMount.ps1
+++ b/Toolkit/Public/Get-RscMssqlLiveMount.ps1
@@ -66,7 +66,7 @@ function Get-RscMssqlLiveMount {
         $nameFilter.texts = $MountedDatabaseName
         $query.Var.filters += $nameFilter
 
-        If ( $PSBoundParameters.ContainsKey('MssqlDatabase') ) {
+        If ( $PSBoundParameters.ContainsKey('RscMssqlDatabase') ) {
             $sourceDatabaseFilter = New-Object -TypeName RubrikSecurityCloud.Types.MssqlDatabaseLiveMountFilterInput
             $sourceDatabaseFilter.Field = "SOURCE_DATABASE_ID"
             $sourceDatabaseFilter.Texts = $RscMssqlDatabase.Id

--- a/Toolkit/Public/Get-RscOracleHost.ps1
+++ b/Toolkit/Public/Get-RscOracleHost.ps1
@@ -30,11 +30,6 @@ function Get-RscOracleHost {
     Param(
         [Parameter(
             Mandatory = $false,
-            ParameterSetName = "Id"
-        )]
-        [String]$Id,
-        [Parameter(
-            Mandatory = $false,
             ParameterSetName = "Name"
         )]
         [String]$Name,
@@ -53,56 +48,40 @@ function Get-RscOracleHost {
     )
     
     Process {
+        $query = New-RscQuery -GqlQuery oracleTopLevelDescendants
+        $query.var.filter = @()
 
-       # The query is different for getting a single object by ID.
-        if ($Id) {
-            $query = New-RscQuery -GqlQuery 
-            $query.var.filter = @()
-            $query.Var.fid = $Id
-
-            $result = Invoke-Rsc -Query $query
-            $result
-        } else {
-            $query = New-RscQuery -GqlQuery oracleTopLevelDescendants
-            $query.var.filter = @()
-
-            if ($Name) {
-                $nameFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
-                # Regex filter doesn't work in the API right now, but we're going to play pretend. 
-                # With real Regex, users could search for VMs that start with the letter A if they wanted.
-                if ($name.Contains("*")) {
-                    $name.Replace("*",'')
-                    $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::REGEX
-                    $nameFilter.texts = $Name.Replace("*",'')
-                } else {
-                    $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::NAME_EXACT_MATCH
-                    $nameFilter.texts = $Name
-                }
-                $query.var.filter += $nameFilter
+        if ($Name) {
+            $nameFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
+            # Regex filter doesn't work in the API right now, but we're going to play pretend. 
+            # With real Regex, users could search for VMs that start with the letter A if they wanted.
+            if ($name.Contains("*")) {
+                $name.Replace("*",'')
+                $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::REGEX
+                $nameFilter.texts = $Name.Replace("*",'')
+            } else {
+                $nameFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::NAME_EXACT_MATCH
+                $nameFilter.texts = $Name
             }
-    
-            if ($Sla) {
-                $slaFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
-                $slaFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::EFFECTIVE_SLA
-                $slaFilter.Texts = $Sla.id
-                $query.var.filter += $slaFilter
-            }
-
-            if ($Cluster) {
-                $clusterFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
-                $clusterFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::CLUSTER_ID
-                $clusterFilter.Texts = $Cluster.id
-                $query.var.filter += $clusterFilter
-            }
-
-            $result = Invoke-Rsc -Query $query
-            $result.nodes
+            $query.var.filter += $nameFilter
         }
 
+        if ($Sla) {
+            $slaFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
+            $slaFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::EFFECTIVE_SLA
+            $slaFilter.Texts = $Sla.id
+            $query.var.filter += $slaFilter
+        }
 
+        if ($Cluster) {
+            $clusterFilter = New-Object -TypeName RubrikSecurityCloud.Types.Filter
+            $clusterFilter.Field = [RubrikSecurityCloud.Types.HierarchyFilterField]::CLUSTER_ID
+            $clusterFilter.Texts = $Cluster.id
+            $query.var.filter += $clusterFilter
+        }
 
-
-
+        $result = Invoke-Rsc -Query $query
+        $result.nodes
     } 
 }
 

--- a/Toolkit/Public/Get-RscSapHanaSystem.ps1
+++ b/Toolkit/Public/Get-RscSapHanaSystem.ps1
@@ -56,7 +56,7 @@ function Get-RscSapHanaSystem {
 
        # The query is different for getting a single object by ID.
         if ($Id) {
-            $query = New-RscQuery -GqlQuery sapHanaSystems
+            $query = New-RscQuery -GqlQuery sapHanaSystem
             $query.var.filter = @()
             $query.Var.fid = $Id
 

--- a/Toolkit/Public/New-RscMssqlSnapshot.ps1
+++ b/Toolkit/Public/New-RscMssqlSnapshot.ps1
@@ -25,8 +25,9 @@ function New-RscMssqlSnapshot {
 
     .EXAMPLE
     Starts an On Demand Snapshot of a MSSQL Database with an SLA Domain ID
+    $sla = Get-RscSla -Name "sdf"
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
-    New-RscMssqlSnapshot -RscMssqlDatabase $RscMssqlDatabase -SLADomain "124d26df-c31f-49a3-a8c3-77b10c9470c2"
+    New-RscMssqlSnapshot -RscMssqlDatabase $RscMssqlDatabase -RscSLADomain $sla
     #>
 
     [CmdletBinding()]


### PR DESCRIPTION
This PR fixes existing bugs in toolkit cmdlets. 
Following is the brief for the same. 

## Type Casting Issues Observed
- Get-RscArchivalLocation

## Id Parameter doesn't specify query in `New-RscQuery -GqlQuery`, so call `-Id` will always fail.
As a solution have removed `-Id` filter, as it's also not mentioned in example.
- Get-RscCloudNativeTagRule 
- Get-RscOracleHost

## Bugs Observed in existing cmdlets
- Get-RscAzureNativeVm
    - All Parameters (-Id, -NameSubstring and -EffectiveSlaIds) were wrongly set. 
- Get-RscCloudNativeTagRule
    - `$query.var.filters = @()` at line 75 wrongly set. It should be `filter` not `filters`
    - Id Parameter doesn't specify query in `New-RscQuery -GqlQuery`
- Get-RscCluster
    - Id filter logic was incorrect and it wasn't working as expected.
- Get-RscDb2Instance
    - Id filter logic was incorrect and it wasn't working as expected.
- Get-RscManagedVolume
    - RscCluster parameter had issue
- Get-RscMssqlLiveMount
    - `RscMssqlDatabase` parameter wrongly used
- Get-RscSapHanaSystem
    - Wrong GQL query specified for -Id parameter
- New-RscMssqlSnapshot
    - Wrong Example specified in comments
- Get-RscArchivalLocation
    - Wrong filter field used for `-Name` parameter (`name` rather than `text`)
    
    
    
 `Get-RscOrganization.Tests.ps1` test is failing because of unrelated reason. 
 Created Jira for this, [here](https://rubrik.atlassian.net/browse/SPARK-507940)
 
 
 Rest all the e2e toolkit tests are passing.
    
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/8980b11e-a69a-476b-bc27-b69442a12ad2" />

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/cb34c225-4890-4274-8e99-e138d55d25b7" />
