### PR TITLE
New-RscSlaArchivalSpecs Pwsh5 Fix

### DIFF
--- a/Toolkit/Public/New-RscSlaArchivalSpecs.ps1
+++ b/Toolkit/Public/New-RscSlaArchivalSpecs.ps1
@@ -164,7 +164,7 @@ function New-RscSlaArchivalSpecs
                 $archivalLocationToClusterMapping = New-Object -TypeName RubrikSecurityCloud.Types.ArchivalLocationToClusterMappingInput
                 $archivalLocationToClusterMapping.ClusterUuid = $ClusterUuids[$i]
                 $archivalLocationToClusterMapping.LocationId = $LocationIds[$i]
-                $slaArchivalSpecs.ArchivalLocationToClusterMapping += $archivalLocationToClusterMapping
+                $slaArchivalSpecs.ArchivalLocationToClusterMapping.add($archivalLocationToClusterMapping)
             }
         }
         $slaArchivalSpecs.archivalTieringSpecInput = $archivalTieringSpecInput


### PR DESCRIPTION
In pwsh5  `$slaArchivalSpecs.ArchivalLocationToClusterMapping += $archivalLocationToClusterMapping` is giving following error 
```
Not able to convert System.Object[] to `RubrikSecurityCloud.Types.ArchivalLocationToClusterMappingInput`
```
Found out that it's happening for the scenarios where right side assignment is list of single object. `add` method is working fine here. 

Although, I was not able to replicate this issue outside of SDK.  