### PR TITLE
Fix get rscorganization test

### DIFF
--- a/Toolkit/Tests/e2e/Get-RscOrganization.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscOrganization.Tests.ps1
@@ -30,9 +30,14 @@ Describe -Name 'Get-RscOrganization Tests' -Tag 'Public' -Fixture {
         }
 
         It -Name 'retrieves single org by name' -Test {
-            $object0 = Get-RscOrganization -Name $data.objects[0].FullName
-            $object0.name | Should -Be $data.objects[0].name
-            $object0.id | Should -Be $data.objects[0].id
+            $filteredObjects = Get-RscOrganization -Name $data.objects[0].FullName
+
+            foreach ($obj in $filteredObjects) {
+                $obj.name | Should -BeLike "*$($data.objects[0].name)*"
+            }
+
+            $ids = $filteredObjects | Where-Object { $_.id -eq $data.objects[0].id }
+            ($ids.Count) | Should -BeExactly 1
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes e2e test for 
Get-RscOrganization Toolkit Cmdlet. 

The test expects was expecting one
 object from `-Name` parameter, 
but it can yield multiple since 
it doesn't check for exact name 
but substring.

## Test
**Test succeeds on pwsh-7**
![image](https://github.com/user-attachments/assets/a8dade41-ee2f-4911-9768-2faa4cadf741)

**Test succeeds on pwsh-5 on windows**
![image](https://github.com/user-attachments/assets/322e65d8-b336-45d0-baf5-8dcb4c213537)

## JIRA
[SPARK-507940](https://rubrik.atlassian.net/browse/SPARK-507940)

