### PR TITLE
Fix Empty Profile

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscGqlPSCmdlet.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscGqlPSCmdlet.cs
@@ -317,12 +317,6 @@ namespace RubrikSecurityCloud.PowerShell.Private
                 fieldProf = Exploration.Profile.DEFAULT;
             }
 
-            // if no patch is given, profile can't be empty:
-            if (!hasPatch && fieldProf == Exploration.Profile.EMPTY)
-            {
-                fieldProf = Exploration.Profile.DEFAULT;
-            }
-
             // read override patch file (if any) and apply it:
             if (fieldProf == Exploration.Profile.DEFAULT ||
                 fieldProf == Exploration.Profile.DETAIL ||

--- a/Tests/unit/EmptyProfile.Tests.ps1
+++ b/Tests/unit/EmptyProfile.Tests.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+Run tests around fields.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name "Test Empty Profile" -Fixture {
+    It -Name "With `Empty` FieldProfile and adding fields using AddField parameter" -Test {
+        $expectedMutation = "mutation MutationBeginManagedVolumeSnapshot(`$input: BeginManagedVolumeSnapshotInput!)`n{`n  beginManagedVolumeSnapshot`n  (`n  input: `$input`n  )`n  {`n  ownerId`n  }`n}`n"
+        $query = (New-RscMutationManagedVolume -Operation BeginSnapshot -FieldProfile EMPTY -AddField OwnerId).GqlRequest().Query
+        $query | Should -BeExactly $expectedMutation
+    }
+
+    It -Name "With `Empty` FieldProfile and adding fields to the query" -Test {
+        $expectedMutation = "mutation MutationBeginManagedVolumeSnapshot(`$input: BeginManagedVolumeSnapshotInput!)`n{`n  beginManagedVolumeSnapshot`n  (`n  input: `$input`n  )`n  {`n  ownerId`n  }`n}`n"
+        $q = New-RscMutationManagedVolume -Operation BeginSnapshot -FieldProfile EMPTY
+        $q.Field.OwnerId="FETCH"
+        $q.GqlRequest().query | Should -BeExactly $expectedMutation
+    }
+
+    It -Name "With Empty FieldProfile and without adding any fields" -Test {
+        $q = New-RscMutationManagedVolume -Operation BeginSnapshot -FieldProfile EMPTY
+        try {
+            $q.GqlRequest()
+            $false | Should -Be $true -Because "An ArgumentException was expected but not thrown."
+        } catch {
+            $_.Exception.InnerException | Should -BeOfType 'System.ArgumentException'
+            $_.Exception.InnerException.Message | Should -BeExactly 'No field specified. A valid GQL query requires at least one field to be included.'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Earlier For Empty Field profile 
the codebase was changing field-profile 
to `DEFAULT`, since it's not 
expected behaviour, it's removed. 
Also put a check if no field profile 
is set then exception will be thrown.

- Added UTs so as to prevent 
  regression in future.

## JIRA 
[SPARK-498279](https://rubrik.atlassian.net/browse/SPARK-498279)

## Tests
- Added UTs to test Empty Field Profile 
- Performed Manual Tests
**With `Empty` FieldProfile and adding fields using AddField parameter**
![image](https://github.com/user-attachments/assets/0693ec6c-78d1-45cc-9c25-3511d6e9f66d)

**With `Empty` FieldProfile and adding fields to the query**
![image](https://github.com/user-attachments/assets/f27d6074-16f4-4fd4-8c90-0d36663e2615)

**With Empty FieldProfile and without adding any fields**
![image](https://github.com/user-attachments/assets/bda2c809-6c2f-4a71-9cef-d74a31259c97)

