### PR TITLE
Fix failing tests because of EMPTY field profile

### DIFF
--- a/Toolkit/Public/Get-RscSla.ps1
+++ b/Toolkit/Public/Get-RscSla.ps1
@@ -556,7 +556,7 @@ function Get-RscSla {
             $result
         } 
         else {
-            $query = New-RscQuery -GqlQuery slaDomains -FieldProfile EMPTY
+            $query = New-RscQuery -GqlQuery slaDomains
             $globalSlaReply = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "globalSlaReply"})
             $query.var.shouldShowProtectedObjectCount = $true
             $query.var.filter = New-Object -TypeName RubrikSecurityCloud.Types.GlobalSlaFilterInput

--- a/Toolkit/Public/Get-RscWorkload.ps1
+++ b/Toolkit/Public/Get-RscWorkload.ps1
@@ -104,7 +104,7 @@ function Get-RscWorkload {
     
     Process {
 
-        $query = New-RscQuery -GqlQuery snappableConnection -FieldProfile EMPTY
+        $query = New-RscQuery -GqlQuery snappableConnection
         $query.Field.Nodes[0].Id = "FOO"
         $query.Field.Nodes[0].Location = "FOO"
         $query.Field.Nodes[0].complianceStatus = [RubrikSecurityCloud.Types.ComplianceStatusEnum]::IN_COMPLIANCE


### PR DESCRIPTION
## Summary 
`Get-RscSla` and `Get-RscWorkload` 
toolkit cmdlet creates query 
with `EMPTY` profile and directly 
access `query.Field.Nodes[0]` 
attribute since `Nodes` will 
not be set in `EMPTY` Profile, 
it will throw error. 
Earlier `EMPTY` profile had 
behaviour similar to `DEFAULT` profile. 
In order to ensure that customer don't 
get any behaviour change, making 
query with  `DEFAULT` 
field profile in these two cmdlets

## Tests 
**Build and Tests succeeded in pwsh5**
![image](https://github.com/user-attachments/assets/a6a738d2-563e-41e2-8ed4-8fd7e63774b2)

**Build and Tests succeeded in pwsh7**
![image](https://github.com/user-attachments/assets/67809602-6bb4-43ab-b20a-a7f106ba9cbd)

## JIRA
[SPARK-498279](https://rubrik.atlassian.net/browse/)
