### PR TITLE
Fix Start Stop Rsc Managed Volume Snapshot

### DIFF
--- a/Toolkit/Public/Start-RscManagedVolumeSnapshot.ps1
+++ b/Toolkit/Public/Start-RscManagedVolumeSnapshot.ps1
@@ -31,7 +31,7 @@ function Start-RscManagedVolumeSnapshot {
     Process {
         Write-Debug "-Running Start-RscManagedVolumeSnapshot"      
         #region Create Query
-        $query = New-RscMutationManagedVolume -Operation BeginSnapshot
+        $query = New-RscMutationManagedVolume -Operation BeginSnapshot -RemoveField RscSnapshotId
         $query.Var.input = New-Object -TypeName RubrikSecurityCloud.Types.BeginManagedVolumeSnapshotInput
         $query.Var.input.id = $RscManagedVolume.Id
         $query.Var.input.config = New-Object -TypeName RubrikSecurityCloud.Types.BeginSnapshotManagedVolumeRequestInput

--- a/Toolkit/Public/Stop-RscManagedVolumeSnapshot.ps1
+++ b/Toolkit/Public/Stop-RscManagedVolumeSnapshot.ps1
@@ -41,7 +41,7 @@ function Stop-RscManagedVolumeSnapshot {
         Write-Debug "-Running Stop-RscManagedVolumeSnapshot"
         
         #region Create Query
-        $query = New-RscMutationManagedVolume -Operation EndSnapshot
+        $query = New-RscMutationManagedVolume -Operation EndSnapshot -RemoveField RscSnapshotId
         $query.Var.input = New-Object -TypeName RubrikSecurityCloud.Types.EndManagedVolumeSnapshotInput
         $query.Var.input.id = $RscManagedVolume.Id
         $query.Var.input.params = New-Object -TypeName RubrikSecurityCloud.Types.EndSnapshotManagedVolumeRequestInput


### PR DESCRIPTION
## Summary 
This PR removes `-RscSnapshotId` field 
from `Start-RscManagedVolumeSnapshot` 
and `Stop-RscManagedVolumeSnapshot` cmdlet. 

The `RscSnapshotId` field excepts input to 
be passed to it, that we are not passing 
currently and since the DEFAULT FieldProfile 
include it, we need 
to explicitly remove it.

This change will remove following cmdlet error
```
Field 'rscSnapshotId' argument 'input' of type
     | 'EndManagedVolumeSnapshotInput!' is required but not provided.
```

## Test Plan
**`Start-RscManagedVolumeSnapshot` manually tested**
![image](https://github.com/user-attachments/assets/c44ae538-b434-453d-ab1e-4503b74fcbe3)


**`Stop-RscManagedVolumeSnapshot` manually tested**
Here we are getting expected err-message. It's not a failure.
`No inflight snapshot exists for managed volume ManagedVolume:::c0aec986-ff3e-4033-bb79-10f96a6cbfb7`

![image](https://github.com/user-attachments/assets/580c5530-ba12-4a57-a0e7-ab39063a42ef)


## JIRA
[SPARK-496743](https://rubrik.atlassian.net/browse/SPARK-496743)




