### PR TITLE
Skip GenDocs for `New-RscQueryAzureNative`

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/docs/GenerateDocs.ps1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/docs/GenerateDocs.ps1
@@ -70,6 +70,13 @@ foreach ($memberItem in $xml.doc.members.member){
         $cmdletName = $cmdLetName.Replace("_","-")
         Write-Output("`nProcessing Cmdlet: " + $cmdletName);
         #Write-Output("Opening markdownd for $cmdletName")
+        
+        # TODO: SPARK-517965 SDK Build fails in GenerateDocs.ps1
+        # see https://rubrik.atlassian.net/browse/SPARK-517965
+        if ($cmdletName -eq "New-RscQueryAzureNative"){
+            Write-Warning("Skipping $cmdletName due to known issue SPARK-517965")
+            continue
+        }
 
         $mdFile = "tmp_help/$($cmdletName).md"
         $cmdletMarkdown = Get-Content -Path $mdFile -Raw -ErrorAction Stop


### PR DESCRIPTION
Skipping `New-RscQueryAzureNative` to unblock release. 
Created Jira for this [here](https://rubrik.atlassian.net/browse/SPARK-517965)