### PR TITLE
MSSQL object handling for Get-RscSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 New Features:
 
 Fixes:
+- Get-RscSnapshot now retrieves snapshots for MSSQL databases. MSSQL database snapshots are tied to the DAG ID, not the ID of the object. Pipeline support now works with Get-RscMssqlDatabase:
+
+```
+# Retrieve all snapshots for "example" database
+Get-RscMssqlDatabase -Name "example" -Relic:$false -Replica:$false | Get-RscSnapshot
+```
 
 Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Fixes:
 Get-RscMssqlDatabase -Name "example" -Relic:$false -Replica:$false | Get-RscSnapshot
 ```
 
+- Protect-RscWorkload now works with MSSQL databases. MSSQL database protection is tied to the DAG ID, not the ID of the object.
+
+```
+# Assign "example" database to the Bronze SLA
+Get-RscMssqlDatabase -Name "example" -Relic:$false -Replica:$false | Protect-RscWorkload -Sla (Get-RscSla Bronze)
+```
+
 Breaking Changes:
 
 ## Version 1.12.6

--- a/Toolkit/Public/Protect-RscWorkload.ps1
+++ b/Toolkit/Public/Protect-RscWorkload.ps1
@@ -36,30 +36,30 @@ function Protect-RscWorkload
   [CmdletBinding()]
   Param(
     # Id of a Workload to be assigned
-    [Parameter(ValueFromPipelineByPropertyName=$true)]
+    [Parameter()]
     [String]$Id,
 
     # Input object that accepts an array of objects for bulk assignment
-    [Parameter()]
+    [Parameter(ValueFromPipeline=$true)]
     $InputObject,
 
     # RSC Sla Object
     [Parameter()]
     [RubrikSecurityCloud.Types.GlobalSlaReply]$Sla,
 
-    # RSC Sla Object
+    # RSC Assignment Type
     [Parameter()]
     [RubrikSecurityCloud.Types.SlaAssignTypeEnum]$AssignmentType = [RubrikSecurityCloud.Types.SlaAssignTypeEnum]::PROTECT_WITH_SLA_ID,
   
-    # RSC Sla Object
+    # RSC Apply to existing snapshots
     [Parameter()]
     [Switch]$ShouldApplyToExistingSnapshots,
 
-    # RSC Sla Object
+    # RSC Apply to non-policy snapshots
     [Parameter()]
     [Switch]$ShouldApplyToNonPolicySnapshots,
 
-    # RSC Sla Object
+    # RSC Snapshot retention setting
     [Parameter()]
     [RubrikSecurityCloud.Types.GlobalExistingSnapshotRetention]$ExistingSnapshotAction
   )
@@ -74,7 +74,12 @@ function Protect-RscWorkload
           $query.Var.Input.ObjectIds = @($Id)
         }
         elseif ($InputObject) {
-          $query.Var.Input.ObjectIds = $InputObject.id
+          if ($InputObject -is [RubrikSecurityCloud.Types.MssqlDatabase]) {
+            $query.Var.Input.ObjectIds = @($InputObject.dagId)
+          }
+          else {
+            $query.Var.Input.ObjectIds = $InputObject.id
+          }
         }
 
         if ($Sla) {

--- a/Toolkit/Tests/e2e/Get-RscSnapshot.Tests.ps1
+++ b/Toolkit/Tests/e2e/Get-RscSnapshot.Tests.ps1
@@ -11,7 +11,12 @@ BeforeAll {
 Describe -Name 'Get-RscSnapshot Tests' -Tag 'Public' -Fixture {
 
     It -Name 'retrieves Snapshots' -Test {
-        $data.snapshots = Get-RscVmwareVm | Select-Object -first 1 | Get-RscSnapshot
+        $data.snapshots = Get-RscVmwareVm -Relic:$false -Replica:$false | Select-Object -first 1 | Get-RscSnapshot
+        $data.snapshots | Should -Not -BeNullOrEmpty
+    }
+
+    It -Name 'retrieves Database Snapshots' -Test {
+        $data.snapshots = Get-RscMssqlDatabase -Relic:$false -Replica:$false | Select-Object -first 1 | Get-RscSnapshot
         $data.snapshots | Should -Not -BeNullOrEmpty
     }
 


### PR DESCRIPTION
- Get-RscSnapshot now retrieves snapshots for MSSQL databases. MSSQL database snapshots are tied to the DAG ID, not the ID of the object. Pipeline support now works with Get-RscMssqlDatabase:

```
# Retrieve all snapshots for "example" database
Get-RscMssqlDatabase -Name "example" -Relic:$false -Replica:$false | Get-RscSnapshot
```

- Protect-RscWorkload now works with MSSQL databases. MSSQL database protection is tied to the DAG ID, not the ID of the object.

```
# Assign "example" database to the Bronze SLA
Get-RscMssqlDatabase -Name "example" -Relic:$false -Replica:$false | Protect-RscWorkload -Sla (Get-RscSla Bronze)
```