### PR TITLE
fix: Properly reset original current working directory upon module import

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
@@ -1,11 +1,11 @@
 #
 # Load Core DLL:
 #
-try {
-    # Record the user's current working directory so that we can return to it when we 
-    # are done loading the module
-    $currentPath = Get-Location
+# Record the user's current working directory so that we can return to it when we 
+# are done loading the module
+$currentPath = Get-Location
 
+try {
     # Determine the module directory based on the PowerShell edition
     If ($PSVersionTable.PSEdition -eq "Desktop") {
        # Write-Host "`nLoading Rubrik Security Cloud PowerShell Module (WindowsPowerShell)...`n"


### PR DESCRIPTION
`$currentPath` was originally set inside the `try` block, which has a different scope than the `finally` block. This resulted in `$currentPath` being `$null` when executing in the `finally` block when used in the call to `Set-Location` which effectively uses the default value for the `-Path` parameter to that cmdlet, which is `.`, or the current working directory--or essentially, it doesn't change locations.

Instead, set `$currentPath` outside the `try` block so that when `Set-Location` is executed in the `finally` block, `$currentPath` has the intended value and effects a change to the current working directory.

Fixes #198.