### PR TITLE
Skip non ga fields

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common/Config.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common/Config.cs
@@ -74,6 +74,9 @@ namespace RubrikSecurityCloud
             // partial matches
             {"status", new List<string>{ "cdmRbacMigrationStatus", "eosStatus" } },
             {"state", null },
+            // TODO (SPARK-): Remove these entries once `OBJECT_PROTECTION_PAUSE` FF is GA
+            {"^cdmPendingObjectPauseAssignment$", new List<string>{ "cdmPendingObjectPauseAssignment" } },
+            {"^rscPendingObjectPauseAssignment$", new List<string>{ "rscPendingObjectPauseAssignment" } },
         };
 
         /// <summary>

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common/Config.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common/Config.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -46,6 +47,16 @@ namespace RubrikSecurityCloud
         public static uint ApiClientTimeOutMinutes = 6;
 
         /// <summary>
+        /// List of fields that should be not be selected for consumption
+        /// </summary>
+        /// TODO (SPARK-548179): Unskip these fields once it reaches GA.
+        public static readonly HashSet<string> FieldsToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "CdmPendingObjectPauseAssignment",
+            "RscPendingObjectPauseAssignment"
+        };
+
+        /// <summary>
         /// Default profile leaf pattern. Keys are patterns to match against
         /// leaf node names. Values are lists of exceptions to the pattern.
         /// </summary>
@@ -74,9 +85,6 @@ namespace RubrikSecurityCloud
             // partial matches
             {"status", new List<string>{ "cdmRbacMigrationStatus", "eosStatus" } },
             {"state", null },
-            // TODO (SPARK-): Remove these entries once `OBJECT_PROTECTION_PAUSE` FF is GA
-            {"^cdmPendingObjectPauseAssignment$", new List<string>{ "cdmPendingObjectPauseAssignment" } },
-            {"^rscPendingObjectPauseAssignment$", new List<string>{ "rscPendingObjectPauseAssignment" } },
         };
 
         /// <summary>

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common/FragmentFactory.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common/FragmentFactory.cs
@@ -345,6 +345,11 @@ namespace RubrikSecurityCloud
                     string propertyName = inputObjProperty.Name;
                     try
                     {
+                        if (Config.FieldsToSkip.Contains(propertyName))
+                        {
+                            inputObjProperty.SetValue(inputObject, null);
+                            continue;
+                        }
                         Type basePropertyType = GetNullableUnderlyingType(inputObjProperty);
 
                         if (IsNullableEnum(inputObjProperty))
@@ -356,7 +361,7 @@ namespace RubrikSecurityCloud
                         {
                             inputObjProperty.SetValue(inputObject, InitializeSimpleValue(basePropertyType));
                         }
-                        
+
                         else if (basePropertyType.IsClass && maxDepth > 0)
                         {
                             //Check if the property is a list
@@ -386,13 +391,13 @@ namespace RubrikSecurityCloud
                                                 testList.Add(testItem);
                                                 compatInterfaceReturned = true;
                                             }
-                                            catch(Exception ex)
+                                            catch (Exception ex)
                                             {
                                                 if (retryCount >= 10) continue;
                                                 retryCount++;
-                                                Console.WriteLine($"Concrete class not suitable, "+
+                                                Console.WriteLine($"Concrete class not suitable, " +
                                                     $"trying again. Retries: {retryCount}." +
-                                                    $" MESSAGE: { ex.Message}");
+                                                    $" MESSAGE: {ex.Message}");
 
                                                 compatInterfaceReturned = false;
                                             }
@@ -421,7 +426,7 @@ namespace RubrikSecurityCloud
                                             }
                                         }
                                     }
-                                    
+
                                     list.Add(item);
                                     inputObjProperty.SetValue(inputObject, list);
                                 }
@@ -446,7 +451,7 @@ namespace RubrikSecurityCloud
                                 int nextDepth = currentDepth + 1;
                                 item?.InitializeToDefaultValues(maxDepth, nextDepth);
                             }
-                            inputObjProperty.SetValue(inputObject, item);       
+                            inputObjProperty.SetValue(inputObject, item);
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## Summary
[PR59287](https://github.com/scaledata/sdmain/pull/59287/files#diff-3194e54f980e15d769a0320d1779103a6c4afd59e9b908fad206b781205f8bd2) introduced two 
new fields cdmPendingObjectPauseAssignment 
and rscPendingObjectPauseAssignment which 
is behind OBJECT_PROTECTION_PAUSE FF, 
backend-work for this is not yet completed 
so it will not go GA for quite some time i guess. 
This is causing SDK tests to fail, because 
these fields are getting included in some 
cmdlets by default.

This PR is skipping these fields from consumption.

Also created [SPARK-548179](https://rubrik.atlassian.net/browse/SPARK-548179) to unskip 
these fields once it reaches GA.

## Test Plan
- SDK Tests Run

![image](https://github.com/user-attachments/assets/25995cbd-59c0-4a6d-b1c9-ed3a32f8ce3a)

## JIRA
[SPARK-548620](https://rubrik.atlassian.net/browse/SPARK-548620)