### PR TITLE
Fix GraphQLClient.cs Exception Handling

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
@@ -324,9 +324,8 @@ namespace RubrikSecurityCloud.NetSDK.Client
             }
             logGraphQLResponse<T>(response, logger);
             
-            if (response.Errors != null ||
-                response.StatusCode >= System.Net.HttpStatusCode.BadRequest ||
-                localError != null)
+            if (localError != null || response.Errors != null ||
+                response.StatusCode >= System.Net.HttpStatusCode.BadRequest)
             {
                 string msg = "The request generated an error.\n" +
                     this.GraphQLRequestToString(Request) + "\n\n" +


### PR DESCRIPTION
## Description
On [this](https://rubrikinc.slack.com/archives/C053UBHTBUH/p1742266198740229) slack thread we are seeing 
that customer is getting 
`Object reference not set to an instance of an object.` 
error occassionally while executing 
`vSphereVmNewConnection`.


Found out that it's happening 
because we are not doing 
exception handling properly, 
which is fixed in this PR.

## Test Plan:
Tried throwing exception, and 
replicated the situation that customer is getting.
![image](https://github.com/user-attachments/assets/ef395b80-5efe-424d-bdf2-862f09d43a29)

Error while executing. 
![image](https://github.com/user-attachments/assets/f8bb93a4-f214-4ecf-a085-582faed7facc)


Now fixed it by proper error-handling, 
executing pwsh command now 
give proper exception. 
![image](https://github.com/user-attachments/assets/45140ef4-47ae-4579-9c88-2f81293a66ee)



