### PR TITLE
Fix MSSQL DagID error 

### DIFF
--- a/Toolkit/Public/Protect-RscWorkload.ps1
+++ b/Toolkit/Public/Protect-RscWorkload.ps1
@@ -74,12 +74,7 @@ function Protect-RscWorkload
           $query.Var.Input.ObjectIds = @($Id)
         }
         elseif ($InputObject) {
-          if ($InputObject -is [RubrikSecurityCloud.Types.MssqlDatabase]) {
-            $query.Var.Input.ObjectIds = @($InputObject.dagId)
-          }
-          else {
-            $query.Var.Input.ObjectIds = $InputObject.id
-          }
+          $query.Var.Input.ObjectIds = $InputObject.id
         }
 
         if ($Sla) {


### PR DESCRIPTION
## Summary:
- `Protect-RscWorkload.ps1` script uses the MSSQL DagID over ObjectID in the GQL operations.
 Which is causing issues when assigning SLAs, as it expects ObjectID.  This issue is observed in v1.13.1. 
This PR fixes the issue.
- Snapshot uses DagID as mentioned in #195, so, `Get-RscSnapshot `is not updated.


## Test Plan:
- I was able to reproduce the error in v1.13.1

Tested the changes
```
Get-RscMssqlDatabase -Name 'TEST_DB' -ErrorAction Stop | Protect-RscWorkload -AssignmentType DO_NOT_PROTECT -ExistingSnapshotAction RETAIN_SNAPSHOTS -ErrorAction Stop

Success
-------
   True
```

## Jira:
SPARK-626572

## Revert Plan:
NA




 