### PR TITLE
Skip non ga fields from autofield

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common/Autofield.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common/Autofield.cs
@@ -85,6 +85,7 @@ namespace RubrikSecurityCloud
             ExcludedFields.Clear();
             LoopyFields.Clear();
             PatchSet.Reset();
+            PatchSet.ReadFromArrays(null, Config.FieldsToSkip.ToArray());
         }
 
         public static bool Excludes(string nodeName, bool isLeaf = false)


### PR DESCRIPTION
## Summary
There we 2 code paths in concern here.
- Autofield._Includes() -> This decides what all fields to be included based of field-profile
- FragmentFactory.InitializeToDefaultValues() - Initialization of all fields to default values. Used by some cmdlets like `Get-RscFileset`. 

Recently we had following two fields introduced in schema which automatically gets included in Autofield and started being initialised in `InitializeToDefaultValues` method, this started causing test-case failures and made cmdlets to fail as these fields are not GAed yet, so customers were getting permission issue. 
```
CdmPendingObjectPauseAssignment
RscPendingObjectPauseAssignment
```

The 2nd part `FragmentFactory.InitializeToDefaultValues() ` was already solved by 
[PR201](https://github.com/rubrikinc/rubrik-powershell-sdk/pull/201)

But 1st part still remain to be an issue. 
This PR solves the first part, by skipping these field from being part of Autofield._Includes()

## Test Plan
Ran following query and confirmed it's no longer including the Non-GAed fields. 
```
$query = New-RscQuery -GqlQuery mssqlDatabaseLiveMounts -AddField Nodes.CreationDate, Nodes.RecoveryPoint, Nodes.SourceDatabase
$query.invoke()
```
<img width="1359" height="942" alt="image" src="https://github.com/user-attachments/assets/d2056338-03f6-4f7a-be41-bbfc15078e95" />


## JIRA
SPARK-700863

