### PR TITLE
Fix Write-Output pollution in PublicFunctions.psm1

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/PublicFunctions.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/PublicFunctions.psm1
@@ -9,7 +9,7 @@ Foreach ($import in @($Public))
 {
     Try
     {
-        Write-Output("Importing module from file $($import.fullname)")
+        Write-Verbose "Importing module from file $($import.fullname)"
         Import-Module $import.fullname -ErrorAction Stop -Force
     }
     Catch


### PR DESCRIPTION
Change Write-Output to Write-Verbose when importing module files. Write-Output sends strings to the pipeline, which pollutes output when Import-Module is captured or piped. Write-Verbose is silent by default and only shows with -Verbose.