### PR TITLE
Improve version mismatch warnings with severity levels

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/RubrikSecurityCloud.Common.Tests.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/RubrikSecurityCloud.Common.Tests.csproj
@@ -16,5 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RubrikSecurityCloud.Schema\RubrikSecurityCloud.Schema.csproj" />
+    <ProjectReference Include="..\RubrikSecurityCloud.PowerShell\RubrikSecurityCloud.PowerShell.csproj" />
   </ItemGroup>
 </Project>

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/VersionHelperTests.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/VersionHelperTests.cs
@@ -1,0 +1,145 @@
+using System;
+using NUnit.Framework;
+using RubrikSecurityCloud.PowerShell.Private;
+
+namespace RubrikSecurityCloud.Tests
+{
+    [TestFixture]
+    public class VersionHelperTests
+    {
+        // ── ExtractDate ─────────────────────────────────────────────
+
+        [Test]
+        public void ExtractDate_StandardFormat()
+        {
+            var date = VersionHelper.ExtractDate("v20260223-52");
+            Assert.IsNotNull(date);
+            Assert.AreEqual(new DateTime(2026, 2, 23), date.Value);
+        }
+
+        [Test]
+        public void ExtractDate_WithoutPrefix()
+        {
+            var date = VersionHelper.ExtractDate("20260223-52");
+            Assert.IsNotNull(date);
+            Assert.AreEqual(new DateTime(2026, 2, 23), date.Value);
+        }
+
+        [Test]
+        public void ExtractDate_NoBuildSuffix()
+        {
+            var date = VersionHelper.ExtractDate("v20230101");
+            Assert.IsNotNull(date);
+            Assert.AreEqual(new DateTime(2023, 1, 1), date.Value);
+        }
+
+        [Test]
+        public void ExtractDate_NullReturnsNull()
+        {
+            Assert.IsNull(VersionHelper.ExtractDate(null));
+        }
+
+        [Test]
+        public void ExtractDate_EmptyReturnsNull()
+        {
+            Assert.IsNull(VersionHelper.ExtractDate(""));
+        }
+
+        [Test]
+        public void ExtractDate_GarbageReturnsNull()
+        {
+            Assert.IsNull(VersionHelper.ExtractDate("not-a-version"));
+        }
+
+        [Test]
+        public void ExtractDate_InvalidDateReturnsNull()
+        {
+            // 13th month doesn't exist
+            Assert.IsNull(VersionHelper.ExtractDate("v20231301-1"));
+        }
+
+        // ── Compare ─────────────────────────────────────────────────
+
+        [Test]
+        public void Compare_SdkOlder()
+        {
+            var result = VersionHelper.Compare("v20260101-10", "v20260301-20");
+            Assert.AreEqual(VersionHelper.Direction.SdkOlder, result.Direction);
+            Assert.IsNotNull(result.Delta);
+            Assert.AreEqual(59, (int)result.Delta.Value.TotalDays);
+        }
+
+        [Test]
+        public void Compare_SdkNewer()
+        {
+            var result = VersionHelper.Compare("v20260301-20", "v20260101-10");
+            Assert.AreEqual(VersionHelper.Direction.SdkNewer, result.Direction);
+            Assert.IsNotNull(result.Delta);
+            Assert.AreEqual(59, (int)result.Delta.Value.TotalDays);
+        }
+
+        [Test]
+        public void Compare_Equal()
+        {
+            var result = VersionHelper.Compare("v20260223-52", "v20260223-99");
+            Assert.AreEqual(VersionHelper.Direction.Equal, result.Direction);
+            Assert.AreEqual(TimeSpan.Zero, result.Delta);
+        }
+
+        [Test]
+        public void Compare_UnknownWhenBothInvalid()
+        {
+            var result = VersionHelper.Compare("garbage", "trash");
+            Assert.AreEqual(VersionHelper.Direction.Unknown, result.Direction);
+            Assert.IsNull(result.Delta);
+        }
+
+        [Test]
+        public void Compare_UnknownWhenOneNull()
+        {
+            var result = VersionHelper.Compare(null, "v20260101-1");
+            Assert.AreEqual(VersionHelper.Direction.Unknown, result.Direction);
+            Assert.IsNull(result.Delta);
+        }
+
+        // ── IsSignificant ───────────────────────────────────────────
+
+        [Test]
+        public void IsSignificant_UnderThreshold()
+        {
+            // 10 days apart — should be Info, not significant
+            var result = VersionHelper.Compare("v20260101-1", "v20260111-1");
+            Assert.IsFalse(VersionHelper.IsSignificant(result));
+        }
+
+        [Test]
+        public void IsSignificant_OverThreshold()
+        {
+            // 60 days apart — should be Warning
+            var result = VersionHelper.Compare("v20260101-1", "v20260302-1");
+            Assert.IsTrue(VersionHelper.IsSignificant(result));
+        }
+
+        [Test]
+        public void IsSignificant_ExactlyAtThreshold()
+        {
+            // Exactly 30 days — should be Warning (>=)
+            var result = VersionHelper.Compare("v20260101-1", "v20260131-1");
+            Assert.IsTrue(VersionHelper.IsSignificant(result));
+        }
+
+        [Test]
+        public void IsSignificant_UnknownAlwaysSignificant()
+        {
+            var result = VersionHelper.Compare("garbage", "trash");
+            Assert.IsTrue(VersionHelper.IsSignificant(result));
+        }
+
+        [Test]
+        public void IsSignificant_EqualNotSignificant()
+        {
+            var result = VersionHelper.Compare("v20260101-1", "v20260101-5");
+            Assert.IsFalse(VersionHelper.IsSignificant(result));
+        }
+    }
+}

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscSessionInfo.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscSessionInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -69,9 +69,52 @@ namespace RubrikSecurityCloud.PowerShell.Private
 
 			if (_schemaVersion != _serverVersion)
 			{
-				_logger.Warning($"The installed RSC SDK version does not " +
-				$"match the server version.");
+				LogVersionMismatchWarning();
 			}
+		}
+
+		/// <summary>
+		/// Logs a version mismatch message with severity based on the age
+		/// of the drift. Less than 30 days: Info. 30+ days: Warning.
+		/// </summary>
+		private void LogVersionMismatchWarning()
+		{
+			var result = VersionHelper.Compare(_schemaVersion, _serverVersion);
+			bool isSignificant = VersionHelper.IsSignificant(result);
+			string deltaInfo = result.Delta.HasValue
+				? $" ({(int)result.Delta.Value.TotalDays} days apart)"
+				: "";
+
+			string message;
+			switch (result.Direction)
+			{
+				case VersionHelper.Direction.SdkOlder:
+					message = $"SDK schema version ({_schemaVersion}) is older " +
+						$"than the server version ({_serverVersion}){deltaInfo}. " +
+						(isSignificant
+							? "Consider updating: Run 'Update-Module RubrikSecurityCloud'."
+							: "A minor version difference is generally safe.");
+					break;
+
+				case VersionHelper.Direction.SdkNewer:
+					message = $"SDK schema version ({_schemaVersion}) is newer " +
+						$"than the server version ({_serverVersion}){deltaInfo}. " +
+						(isSignificant
+							? "Some SDK features may not be available on this server."
+							: "A minor version difference is generally safe.");
+					break;
+
+				default:
+					message = $"SDK schema version ({_schemaVersion}) does not " +
+						$"match server version ({_serverVersion}). " +
+						"Run 'Get-RscVersion' to check current versions.";
+					break;
+			}
+
+			if (isSignificant)
+				_logger.Warning(message);
+			else
+				_logger.Info(message);
 		}
 
 		/// <summary>
@@ -99,4 +142,3 @@ namespace RubrikSecurityCloud.PowerShell.Private
 		}
 	}
 }
-

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/VersionHelper.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/VersionHelper.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RubrikSecurityCloud.Common.Tests")]
+
+// ignore warning 'Missing XML comment'
+#pragma warning disable 1591
+
+namespace RubrikSecurityCloud.PowerShell.Private
+{
+	/// <summary>
+	/// Pure helper for parsing and comparing SDK/server schema versions.
+	/// Versions follow the format "v20230524-16" (vYYYYMMDD-build).
+	/// </summary>
+	internal static class VersionHelper
+	{
+		/// <summary>
+		/// Threshold: version drift below this is informational,
+		/// above is a warning.
+		/// </summary>
+		internal static readonly TimeSpan WarningThreshold = TimeSpan.FromDays(30);
+
+		internal enum Direction
+		{
+			SdkOlder,
+			SdkNewer,
+			Equal,
+			Unknown
+		}
+
+		internal struct CompareResult
+		{
+			public Direction Direction;
+			public TimeSpan? Delta;
+		}
+
+		/// <summary>
+		/// Compares SDK and server versions by their embedded dates.
+		/// </summary>
+		internal static CompareResult Compare(string sdkVersion, string serverVersion)
+		{
+			var sdkDate = ExtractDate(sdkVersion);
+			var serverDate = ExtractDate(serverVersion);
+
+			if (sdkDate.HasValue && serverDate.HasValue)
+			{
+				if (sdkDate.Value == serverDate.Value)
+					return new CompareResult { Direction = Direction.Equal, Delta = TimeSpan.Zero };
+
+				var delta = (serverDate.Value - sdkDate.Value).Duration();
+				var dir = sdkDate.Value < serverDate.Value
+					? Direction.SdkOlder
+					: Direction.SdkNewer;
+				return new CompareResult { Direction = dir, Delta = delta };
+			}
+
+			return new CompareResult { Direction = Direction.Unknown, Delta = null };
+		}
+
+		/// <summary>
+		/// Extracts the date from a version string like "v20230524-16".
+		/// Returns null if the format is not recognized.
+		/// </summary>
+		internal static DateTime? ExtractDate(string version)
+		{
+			if (string.IsNullOrEmpty(version))
+				return null;
+
+			var match = System.Text.RegularExpressions.Regex.Match(
+				version, @"v?(\d{8})");
+			if (match.Success && match.Groups.Count > 1)
+			{
+				if (DateTime.TryParseExact(
+					match.Groups[1].Value, "yyyyMMdd",
+					null, System.Globalization.DateTimeStyles.None,
+					out DateTime date))
+				{
+					return date;
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Returns true if the delta is significant enough to warrant a warning.
+		/// </summary>
+		internal static bool IsSignificant(CompareResult result)
+		{
+			if (result.Direction == Direction.Unknown)
+				return true;
+			return result.Delta.HasValue &&
+				result.Delta.Value >= WarningThreshold;
+		}
+	}
+}

--- a/Toolkit/Private/Show-RscAbout.ps1
+++ b/Toolkit/Private/Show-RscAbout.ps1
@@ -211,8 +211,13 @@ function Show-RscAbout {
     $tagY1 = 21; $tagY2 = 22
     $tagLeft = 21
     $tagRight = 52
-    _At $tagLeft $tagY1; _W $DG '·····'; _W $T3 '▸ '; _W $GR 'Rubrik Security Cloud  '; _W $T3 '◂'; _W $DG '·····'
-    _At $tagLeft $tagY2; _W $DG '·····'; _W $T3 '▸ '; _W $GR 'GraphQL API  ·  SDK    '; _W $T3 '◂'; _W $DG '·····'
+    _At $tagLeft $tagY1; _W $DG '·····'; _W $T3 '▸ '; _W (_fg 229) 'Rubrik Security Cloud  '; _W $T3 '◂'; _W $DG '·····'
+    # SDK version line: centered in 23 chars (same width as tagline above)
+    $sdkVer = try { "v" + (Get-Module RubrikSecurityCloud).Version.ToString() } catch { '?' }
+    if ($sdkVer.Length -gt 23) { $sdkVer = $sdkVer.Substring(0, 22) + '…' }
+    $pad = [Math]::Max(0, 23 - $sdkVer.Length)
+    $verLabel = (' ' * [Math]::Floor($pad / 2)) + $sdkVer + (' ' * [Math]::Ceiling($pad / 2))
+    _At $tagLeft $tagY2; _W $DG '·····'; _W $T3 '▸ '; _W $GR $verLabel; _W $T3 '◂'; _W $DG '·····'
 
     $frame = 0
     $mqOff = 0
@@ -235,6 +240,29 @@ function Show-RscAbout {
                     else {
                         _W '' ' '
                     }
+                }
+            }
+
+            # ── RSC title wave: gentle pulse right→left ──────────
+            # Palette: 101 (dim olive) → 107 (sage) → 143 (light olive) → 144 (khaki) → back
+            $rscText = 'Rubrik Security Cloud'
+            $rscCol = $tagLeft + 7
+            $rscLen = $rscText.Length
+            # ~7 frames for wave to cross (4x speed) + ~77 pause ≈ 10s
+            $waveCycle = [Math]::Floor(($rscLen + 4) / 4) + 77
+            $waveFrame = $frame % $waveCycle
+            $wavePos = $rscLen + 1 - ($waveFrame * 4)  # 4x speed, right to left
+            for ($ci = 0; $ci -lt $rscLen; $ci++) {
+                _At ($rscCol + $ci) $tagY1
+                $dist = [Math]::Abs($ci - $wavePos)
+                if ($dist -eq 0) {
+                    _W (_fg 144) $rscText[$ci]     # khaki (peak)
+                } elseif ($dist -eq 1) {
+                    _W (_fg 143) $rscText[$ci]     # light olive
+                } elseif ($dist -eq 2) {
+                    _W (_fg 107) $rscText[$ci]     # sage
+                } else {
+                    _W (_fg 101) $rscText[$ci]     # dim olive (base)
                 }
             }
 


### PR DESCRIPTION
- Parse date from schema versions (v20230524-16 format) to determine SDK-older vs SDK-newer and the age of the drift
- Delta < 30 days: log as Info ("minor version difference is safe")
- Delta >= 30 days: log as Warning with actionable guidance
- Unknown format: always Warning
- Show days apart in the message for clarity

Supersedes PR #207.