### PR TITLE
Split param validation tests from e2e to unit tests

### DIFF
--- a/Tests/e2e/Get-RscFileset.Tests.ps1
+++ b/Tests/e2e/Get-RscFileset.Tests.ps1
@@ -1,58 +1,24 @@
 <#
 .SYNOPSIS
-Run tests specifically for Get-RscFileset
+E2e tests for Get-RscFileset (requires live RSC connection).
+Parameter validation tests are in Tests/unit/Get-RscFileset.Tests.ps1.
 #>
 BeforeAll {
     . "$PSScriptRoot\..\E2eTestInit.ps1"
 }
 
-
-Describe -Name 'Get-RscFileset Tests' -Tag 'Public' -Fixture{
-    #Fileset by  FilesetId tests
-    Context -Name 'Id ParameterSet Validation'{
-        It -Name 'FilesetId cannot be $null' -Test {
-            { Get-RscFileset -FilesetId $null }|
-            Should -Throw "Cannot validate argument on parameter 'FilesetId'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-    }
-
+Describe -Name 'Get-RscFileset Tests' -Tag 'Public' -Fixture {
     Context -Name "Call with HostId" {
-
         It -Name "First 3 Windows Hosts from Get-RscHost" -Test {
             $hosts = Get-RscHost -OsType Windows -First 3
-            # Bypass the test if there are no Windows hosts
             if ($hosts.Count -eq 0) {
-                Skip "No Windows hosts found"
+                Set-ItResult -Skipped -Because "No Windows hosts found"
+                return
             }
-            # for each host, get the filesets
             $hosts | ForEach-Object {
                 $hostId = $_.Id
                 Get-RscFileset -HostId $hostId
             }
-        }
-    }
-
-    # TODO: SPARK-225906 fix this test
-    return
-
-    #Query tests
-    Context -Name 'Query ParameterSet Validation' {
-
-        It -Name 'Parameter HostId(alias Id) shoud accept value from pipeline' -Test{
-            # TODO: SPARK-212380 Replace the static ID below with a mock test once the mock server has been fixed.
-            { New-Object PSObject -Property @{"Id"="0058bb59-adc4-598e-972a-ecd702624c7a"} | Get-RscFileset } | 
-                Should -Not -Throw
-        }
-
-
-        It -Name 'Parameter HostId(alias: Id) cannot be $null' -Test {
-            { Get-RscFileset -HostId $null} |
-                Should -Throw "Cannot validate argument on parameter 'HostId'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
-        It -Name 'Parameter HostId(alias: Id) cannot be empty' -Test {
-            { Get-RscFileset -Id '' } |
-                Should -Throw "Cannot validate argument on parameter 'HostId'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
         }
     }
 }

--- a/Tests/e2e/Get-RscFilesetTemplate.Tests.ps1
+++ b/Tests/e2e/Get-RscFilesetTemplate.Tests.ps1
@@ -1,44 +1,14 @@
 <#
 .SYNOPSIS
-Run tests around fileset templates
+E2e tests for Get-RscFilesetTemplate (requires live RSC connection).
+Parameter validation tests are in Tests/unit/Get-RscFilesetTemplate.Tests.ps1.
 #>
 BeforeAll {
     . "$PSScriptRoot\..\E2eTestInit.ps1"
 }
 
-
-Describe -Name 'Get-RscFilesetTemplate Tests' -Tag 'Public' -Fixture{
-    Context -Name 'Parameter Validation' {
-        It -Name 'Parameter Name can be $null' -Test {
-            { Get-RscFilesetTemplate -OsType Windows -Name $null } |
-                Should -Not -Throw
-        }
-
-        It -Name 'Parameter Name can be empty' -Test {
-            { Get-RscFilesetTemplate -OsType Windows -Name '' } |
-                Should -Not -Throw
-        }
-
-        It -Name 'Parameter ID cannot be $null' -Test {
-            { Get-RscFilesetTemplate -Id $null } |
-                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
-        It -Name 'Parameter ID cannot be empty' -Test {
-            { Get-RscFilesetTemplate -Id '' } |
-                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
-        It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
-            { Get-RscFilesetTemplate -Id my-host-id-that-doesnot-exist -Name 'swagsanta' } |
-                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscFilesetTemplate'
-        }
-
-        It -Name 'Parameter OsType cannot be $null' -Test{
-            {Get-RscFilesetTemplate -OsType $null } |
-            Should -Throw "Cannot validate argument on parameter 'OsType'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
+Describe -Name 'Get-RscFilesetTemplate Tests' -Tag 'Public' -Fixture {
+    Context -Name 'Live query' {
         It -Name 'Fields work as expected' -Test {
             $fields = Get-RscType -Name FilesetTemplate -InitialProperties @("Name","OsType")
             $results = Get-RscFilesetTemplate -OsType Windows -Field $fields -First 1

--- a/Tests/e2e/Get-RscHost.Tests.ps1
+++ b/Tests/e2e/Get-RscHost.Tests.ps1
@@ -1,45 +1,14 @@
 <#
 .SYNOPSIS
-Run tests around hosts
+E2e tests for Get-RscHost (requires live RSC connection).
+Parameter validation tests are in Tests/unit/Get-RscHost.Tests.ps1.
 #>
+BeforeAll {
+    . "$PSScriptRoot\..\E2eTestInit.ps1"
+}
 
-
-Describe -Name 'Get-RscHost Tests' -Tag 'Public' -Fixture{
-    BeforeAll {
-        . "$PSScriptRoot\..\E2eTestInit.ps1"
-    }
-
-    Context -Name 'Parameter Validation' {
-        It -Name 'Parameter Name can be $null' -Test {
-            { Get-RscHost -OsType Windows -Name $null } |
-                Should -Not -Throw 
-        }
-
-        It -Name 'Parameter Name can be empty' -Test {
-            { Get-RscHost -OsType Windows -Name '' } |
-                Should -Not -Throw
-        }
-
-        It -Name 'Parameter ID cannot be $null' -Test {
-            { Get-RscHost -Id $null } |
-                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
-        It -Name 'Parameter ID cannot be empty' -Test {
-            { Get-RscHost -Id '' } |
-                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
-        It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
-            { Get-RscHost -Id my-host-id-that-doesnot-exist -Name 'swagsanta' } |
-                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscHost'
-        }
-
-        It -Name 'Parameter OsType cannot be $null' -Test{
-            {Get-RscHost -OsType $null } |
-            Should -Throw "Cannot validate argument on parameter 'OsType'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
-        }
-
+Describe -Name 'Get-RscHost Tests' -Tag 'Public' -Fixture {
+    Context -Name 'Live query' {
         It -Name 'Fields work as expected' -Test {
             $fields = Get-RscType -Name PhysicalHost -InitialProperties @("Name","OsType")
             $results = Get-RscHost -OsType Windows -Field $fields -First 1

--- a/Tests/unit/Get-RscFileset.Tests.ps1
+++ b/Tests/unit/Get-RscFileset.Tests.ps1
@@ -1,0 +1,17 @@
+<#
+.SYNOPSIS
+Unit tests for Get-RscFileset parameter validation.
+Extracted from Tests/e2e/Get-RscFileset.Tests.ps1 — no RSC connection needed.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name 'Get-RscFileset Parameter Validation' -Tag 'Public' -Fixture {
+    Context -Name 'Id ParameterSet Validation' {
+        It -Name 'FilesetId cannot be $null' -Test {
+            { Get-RscFileset -FilesetId $null } |
+            Should -Throw "Cannot validate argument on parameter 'FilesetId'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+    }
+}

--- a/Tests/unit/Get-RscFilesetTemplate.Tests.ps1
+++ b/Tests/unit/Get-RscFilesetTemplate.Tests.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+Unit tests for Get-RscFilesetTemplate parameter validation.
+Extracted from Tests/e2e/Get-RscFilesetTemplate.Tests.ps1 — no RSC connection needed.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name 'Get-RscFilesetTemplate Parameter Validation' -Tag 'Public' -Fixture {
+    Context -Name 'Parameter Validation' {
+        It -Name 'Parameter ID cannot be $null' -Test {
+            { Get-RscFilesetTemplate -Id $null } |
+                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+
+        It -Name 'Parameter ID cannot be empty' -Test {
+            { Get-RscFilesetTemplate -Id '' } |
+                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+
+        It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
+            { Get-RscFilesetTemplate -Id my-host-id-that-doesnot-exist -Name 'swagsanta' } |
+                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscFilesetTemplate'
+        }
+
+        It -Name 'Parameter OsType cannot be $null' -Test {
+            { Get-RscFilesetTemplate -OsType $null } |
+            Should -Throw "Cannot validate argument on parameter 'OsType'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+    }
+}

--- a/Tests/unit/Get-RscHost.Tests.ps1
+++ b/Tests/unit/Get-RscHost.Tests.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+Unit tests for Get-RscHost parameter validation.
+Extracted from Tests/e2e/Get-RscHost.Tests.ps1 — no RSC connection needed.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name 'Get-RscHost Parameter Validation' -Tag 'Public' -Fixture {
+    Context -Name 'Parameter Validation' {
+        It -Name 'Parameter ID cannot be $null' -Test {
+            { Get-RscHost -Id $null } |
+                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+
+        It -Name 'Parameter ID cannot be empty' -Test {
+            { Get-RscHost -Id '' } |
+                Should -Throw "Cannot validate argument on parameter 'Id'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+
+        It -Name 'Parameters Id and Name cannot be simultaneously used' -Test {
+            { Get-RscHost -Id my-host-id-that-doesnot-exist -Name 'swagsanta' } |
+                Should -Throw -ErrorId 'AmbiguousParameterSet,RubrikSecurityCloud.PowerShell.Cmdlets.Get_RscHost'
+        }
+
+        It -Name 'Parameter OsType cannot be $null' -Test {
+            { Get-RscHost -OsType $null } |
+            Should -Throw "Cannot validate argument on parameter 'OsType'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+    }
+}


### PR DESCRIPTION
Move parameter validation tests (null/empty/ambiguous checks) for Get-RscFileset, Get-RscFilesetTemplate, and Get-RscHost from Tests/e2e/ to Tests/unit/. These tests verify PowerShell parameter attributes and don't need a live RSC connection.

Tests that accept valid params but require a session (Name can be $null/empty with -OsType) remain in e2e since the cmdlets check for an active connection before param processing.