### PR TITLE
Add -AsQuery to all Toolkit scripts

### DIFF
--- a/Toolkit/Public/Get-RscAccount.ps1
+++ b/Toolkit/Public/Get-RscAccount.ps1
@@ -18,16 +18,32 @@ function Get-RscAccount {
     The User type (returned by the allAccountOwners query):
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/user.doc.html
     
+
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
     #>
 
     [CmdletBinding(
     )]
     Param(
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
         $outputObj = @{}
-        
+
+        if ( $AsQuery ) {
+            $q1 = New-RscQuery -GqlQuery accountId
+            $q2 = New-RscQuery -GqlQuery allAccountOwners -RemoveField AllOrgs.AllClusterCapacityQuotas
+            return @($q1, $q2)
+        }
+
         # Add Account Id:
         $outputObj["AccountId"] = (New-RscQuery -GqlQuery accountId).Invoke()
 

--- a/Toolkit/Public/Get-RscArchivalLocation.ps1
+++ b/Toolkit/Public/Get-RscArchivalLocation.ps1
@@ -11,6 +11,11 @@ function Get-RscArchivalLocation {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all archival locations
     Get-RscArchivalLocation
@@ -37,7 +42,12 @@ function Get-RscArchivalLocation {
             Mandatory = $false,
             ParameterSetName = "Name"
         )]
-        [String]$Name
+        [String]$Name,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -308,6 +318,7 @@ function Get-RscArchivalLocation {
             $query.Field[0].targets[$RubrikManagedTapeTargetType].syncFailureReason = "FETCH"
 
         }
+        if ( $AsQuery ) { return $query }
         $result = Invoke-Rsc $query
         $result.targets
     } 

--- a/Toolkit/Public/Get-RscAwsNativeEc2Instance.ps1
+++ b/Toolkit/Public/Get-RscAwsNativeEc2Instance.ps1
@@ -11,6 +11,11 @@ function Get-RscAwsNativeEc2Instance {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscAwsNativeEc2Instance
@@ -50,7 +55,12 @@ function Get-RscAwsNativeEc2Instance {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -61,6 +71,7 @@ function Get-RscAwsNativeEc2Instance {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -77,6 +88,7 @@ function Get-RscAwsNativeEc2Instance {
                 $query.var.ec2InstanceFilters.effectiveSlaFilter.effectiveSlaIds = @($Sla.Id)
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscAzureNativeVm.ps1
+++ b/Toolkit/Public/Get-RscAzureNativeVm.ps1
@@ -11,6 +11,11 @@ function Get-RscAzureNativeVm {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscAzureNativeVm
@@ -43,7 +48,12 @@ function Get-RscAzureNativeVm {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.GlobalSlaReply]$Sla
+        [RubrikSecurityCloud.Types.GlobalSlaReply]$Sla,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -53,6 +63,7 @@ function Get-RscAzureNativeVm {
             $query = New-RscQuery -GqlQuery azureNativeVirtualMachine
             $query.Var.azureVirtualMachineRubrikId = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -69,6 +80,7 @@ function Get-RscAzureNativeVm {
                 $query.var.virtualMachineFilters.effectiveSlaFilter.effectiveSlaIds = @($Sla.id)
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscCloudNativeTagRule.ps1
+++ b/Toolkit/Public/Get-RscCloudNativeTagRule.ps1
@@ -11,6 +11,11 @@ function Get-RscCloudNativeTagRule {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscCloudNativeTagRule
@@ -44,7 +49,12 @@ function Get-RscCloudNativeTagRule {
             ValueFromPipeline = $false,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.CloudNativeTagObjectType]$ObjectType
+        [RubrikSecurityCloud.Types.CloudNativeTagObjectType]$ObjectType,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -75,6 +85,7 @@ function Get-RscCloudNativeTagRule {
 
             $query.var.ObjectType += $ObjectType
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.tagRules
     } 

--- a/Toolkit/Public/Get-RscCluster.ps1
+++ b/Toolkit/Public/Get-RscCluster.ps1
@@ -34,8 +34,10 @@ function Get-RscCluster {
     with a NULL in them. 
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
-    
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Return a list of all clusters managed by RSC
     
@@ -121,7 +123,11 @@ function Get-RscCluster {
     Process {
         # Count clusters:
         if ( $PSCmdlet.ParameterSetName -eq "Count" ) {
-            $r = (New-RscQuery -GqlQuery clusterConnection -RemoveField Nodes).Invoke()
+            $query = New-RscQuery -GqlQuery clusterConnection -RemoveField Nodes
+            if ( $AsQuery ) {
+                return $query
+            }
+            $r = $query.Invoke()
             # Object's 'Count' property is hidden by the 'Count' method
             # so we can't do `$r.Count`
             $clusterCount = $r | Select-Object -ExpandProperty Count

--- a/Toolkit/Public/Get-RscDb2Database.ps1
+++ b/Toolkit/Public/Get-RscDb2Database.ps1
@@ -11,6 +11,11 @@ function Get-RscDb2Database {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscDb2Database
@@ -49,9 +54,14 @@ function Get-RscDb2Database {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
-    
+
     Process {
 
        # The query is different for getting a single object by ID.
@@ -60,6 +70,7 @@ function Get-RscDb2Database {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -95,6 +106,7 @@ function Get-RscDb2Database {
                 $query.var.filter += $clusterFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscDb2Instance.ps1
+++ b/Toolkit/Public/Get-RscDb2Instance.ps1
@@ -11,6 +11,11 @@ function Get-RscDb2Instance {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscDb2Instance
@@ -49,9 +54,14 @@ function Get-RscDb2Instance {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
-    
+
     Process {
 
        # The query is different for getting a single object by ID.
@@ -60,6 +70,7 @@ function Get-RscDb2Instance {
             $query.var.filter = @()
             $query.Var.id = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -95,6 +106,7 @@ function Get-RscDb2Instance {
                 $query.var.filter += $clusterFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscEventSeries.ps1
+++ b/Toolkit/Public/Get-RscEventSeries.ps1
@@ -39,7 +39,9 @@ function Get-RscEventSeries {
   The DETAIL field profile returns more fields than the DEFAULT field profile.
 
   .PARAMETER AsQuery
-  Instead of running the command, the query object is returned.
+  Return the query object instead of running the query.
+  Preliminary read-only queries may still run to gather IDs or
+  other data needed to build the main query.
 
   .EXAMPLE
   Get-RscEventSeries -First 3

--- a/Toolkit/Public/Get-RscHypervVm.ps1
+++ b/Toolkit/Public/Get-RscHypervVm.ps1
@@ -11,6 +11,11 @@ function Get-RscHypervVm {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscHypervVm
@@ -49,7 +54,12 @@ function Get-RscHypervVm {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -60,6 +70,7 @@ function Get-RscHypervVm {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -95,6 +106,7 @@ function Get-RscHypervVm {
                 $query.var.filter += $clusterFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscManagedVolume.ps1
+++ b/Toolkit/Public/Get-RscManagedVolume.ps1
@@ -22,6 +22,11 @@ function Get-RscManagedVolume {
     RscCluster object retrieved via Get-RscCluster
 
    
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Return back a list of Managed Volumes.
     Get-RscManagedVolume -List
@@ -54,7 +59,12 @@ function Get-RscManagedVolume {
         
         [Parameter(
             Mandatory = $false
-        )][RubrikSecurityCloud.Types.Cluster]$RscCluster
+        )][RubrikSecurityCloud.Types.Cluster]$RscCluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -84,6 +94,7 @@ function Get-RscManagedVolume {
         }
         
         #endregion
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result.Nodes
     }

--- a/Toolkit/Public/Get-RscMongoCollection.ps1
+++ b/Toolkit/Public/Get-RscMongoCollection.ps1
@@ -11,6 +11,11 @@ function Get-RscMongoCollection {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscMongoCollection
@@ -62,7 +67,12 @@ function Get-RscMongoCollection {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.MongoSource]$MongoSource
+        [RubrikSecurityCloud.Types.MongoSource]$MongoSource,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -73,6 +83,7 @@ function Get-RscMongoCollection {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -122,6 +133,7 @@ function Get-RscMongoCollection {
                 $query.var.filter += $MongoDatabaseFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscMongoDatabase.ps1
+++ b/Toolkit/Public/Get-RscMongoDatabase.ps1
@@ -11,6 +11,11 @@ function Get-RscMongoDatabase {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscMongoDatabase
@@ -56,7 +61,12 @@ function Get-RscMongoDatabase {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.MongoSource]$MongoSource
+        [RubrikSecurityCloud.Types.MongoSource]$MongoSource,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -67,6 +77,7 @@ function Get-RscMongoDatabase {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -109,6 +120,7 @@ function Get-RscMongoDatabase {
                 $query.var.filter += $MongoSourceFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscMongoSource.ps1
+++ b/Toolkit/Public/Get-RscMongoSource.ps1
@@ -11,6 +11,11 @@ function Get-RscMongoSource {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscMongoSource
@@ -50,7 +55,12 @@ function Get-RscMongoSource {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -61,6 +71,7 @@ function Get-RscMongoSource {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -96,6 +107,7 @@ function Get-RscMongoSource {
                 $query.var.filter += $clusterFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscMssqlAvailabilityGroup.ps1
+++ b/Toolkit/Public/Get-RscMssqlAvailabilityGroup.ps1
@@ -31,6 +31,11 @@ function Get-RscMssqlAvailabilityGroup {
     .PARAMETER Replica
     Switch to include or exclude replicated AGs
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns a list of Availability Groups in Rubrik, including relics and replicas.
     Get-RscMssqlAvailabilityGroup

--- a/Toolkit/Public/Get-RscMssqlDatabase.ps1
+++ b/Toolkit/Public/Get-RscMssqlDatabase.ps1
@@ -27,6 +27,11 @@ function Get-RscMssqlDatabase {
     .PARAMETER Detail
     Changes the data profile. This can affect the fields returned
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Return a list of MSSQL Databases
     Get-RscMssqlDatabase -List

--- a/Toolkit/Public/Get-RscMssqlDatabaseFiles.ps1
+++ b/Toolkit/Public/Get-RscMssqlDatabaseFiles.ps1
@@ -17,6 +17,11 @@ function Get-RscMssqlDatabaseFiles {
     .PARAMETER RecoveryDateTime
     Use Get-RscMssqlDatabaseRecoveryPoint to get a fully formatted date and time for the recovery point
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns the list of database files based on a specific point in time. 
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
@@ -31,7 +36,13 @@ function Get-RscMssqlDatabaseFiles {
         
         [Parameter(
             Mandatory = $true
-        )][datetime]$RecoveryDateTime
+        )][datetime]$RecoveryDateTime,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     Process {
         # Determine field profile:
@@ -46,6 +57,7 @@ function Get-RscMssqlDatabaseFiles {
         $query.Var.input.id = $RscMssqlDatabase.Id
         $query.Var.input.time = $RecoveryDateTime
 
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result.Items
     } 

--- a/Toolkit/Public/Get-RscMssqlDatabaseRecoverableRanges.ps1
+++ b/Toolkit/Public/Get-RscMssqlDatabaseRecoverableRanges.ps1
@@ -21,6 +21,11 @@ function Get-RscMssqlDatabaseRecoverableRanges {
     .PARAMETER beforeTime
     Used to filter ranges 
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns all of the ranges the database can be recovered to. 
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
@@ -52,7 +57,13 @@ function Get-RscMssqlDatabaseRecoverableRanges {
         [Parameter(
             Mandatory = $false,
             ValueFromPipeline = $false
-        )][datetime]$beforeTime
+        )][datetime]$beforeTime,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -75,6 +86,7 @@ function Get-RscMssqlDatabaseRecoverableRanges {
             $query.Var.input.beforeTime = $beforeTime
         }
 
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result.Data
     } 

--- a/Toolkit/Public/Get-RscMssqlDatabaseRecoveryPoint.ps1
+++ b/Toolkit/Public/Get-RscMssqlDatabaseRecoveryPoint.ps1
@@ -27,6 +27,11 @@ function Get-RscMssqlDatabaseRecoveryPoint {
         - UTC: 2023-11-02 08:00:000Z
     All values will be converted into UTC and used as the recovery point.
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns exact point in time in UTC based on the latest recovery point
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
@@ -56,7 +61,13 @@ function Get-RscMssqlDatabaseRecoveryPoint {
         [Parameter(ParameterSetName = 'LastFull')]
         [switch]$LastFull,
         [Parameter(ParameterSetName = 'RestoreTime')]
-        [datetime]$RestoreTime
+        [datetime]$RestoreTime,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -66,6 +77,7 @@ function Get-RscMssqlDatabaseRecoveryPoint {
         if ($PSBoundParameters.ContainsKey('Latest')) {
             $query = New-RscQueryMssql -Op RecoverableRanges -AddField Data.BeginTime, Data.EndTime
             $query.Var.input.id = $RscMssqlDatabase.id
+            if ( $AsQuery ) { return $query }
             $result = $query.Invoke()
             $LatestRecoveryRange = $result.Data | Sort-Object -Descending -Property EndTime 
             $RecoveryDateTime = $LatestRecoveryRange[0].EndTime.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')

--- a/Toolkit/Public/Get-RscMssqlInstance.ps1
+++ b/Toolkit/Public/Get-RscMssqlInstance.ps1
@@ -33,7 +33,9 @@ function Get-RscMssqlInstance {
     Changes the data profile. This can affect the fields returned
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Returns a list of all SQL Server Hosts and clusters connected to RSC

--- a/Toolkit/Public/Get-RscMssqlLinkedAvailabilityGroup.ps1
+++ b/Toolkit/Public/Get-RscMssqlLinkedAvailabilityGroup.ps1
@@ -11,6 +11,11 @@ function Get-RscMssqlLinkedAvailabilityGroup {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all linked availability groups
     Get-RscMssqlLinkedAvailabilityGroups

--- a/Toolkit/Public/Get-RscMssqlLiveMount.ps1
+++ b/Toolkit/Public/Get-RscMssqlLiveMount.ps1
@@ -17,6 +17,11 @@ function Get-RscMssqlLiveMount {
     .PARAMETER MssqlDatabase
     Database object returned from Get-RscMssqlDatabase
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns the list of database files based on the latest recovery point
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
@@ -34,7 +39,13 @@ function Get-RscMssqlLiveMount {
             Mandatory = $false, 
             ValueFromPipeline = $true
         )]
-        [RubrikSecurityCloud.Types.MssqlDatabase]$RscMssqlDatabase
+        [RubrikSecurityCloud.Types.MssqlDatabase]$RscMssqlDatabase,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -73,6 +84,7 @@ function Get-RscMssqlLiveMount {
             $query.Var.filters += $sourceDatabaseFilter
         }
         #endregion
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result.Nodes
     } 

--- a/Toolkit/Public/Get-RscMssqlLogShipping.ps1
+++ b/Toolkit/Public/Get-RscMssqlLogShipping.ps1
@@ -23,6 +23,11 @@ function Get-RscMssqlLogShipping {
     .PARAMETER Cluster
     Cluster object retrieved via Get-RscCluster
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns a list of all log shipping relationships
     Get-RscMssqlLogShipping
@@ -81,7 +86,13 @@ function Get-RscMssqlLogShipping {
             ValueFromPipeline = $true
         )]
         [Alias("RscCluster")]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -114,6 +125,7 @@ function Get-RscMssqlLogShipping {
             $query.Field.PrimaryCluster.Name = "FETCH"
             $query.Field.PrimaryCluster.Id = "FETCH"
 
+            if ( $AsQuery ) { return $query }
         }
         else {
             $query = New-RscQuery -GqlQuery cdmMssqlLogShippingTargets
@@ -164,6 +176,7 @@ function Get-RscMssqlLogShipping {
             $query.Field.Nodes[0].PrimaryCluster.Name = "FETCH"
             $query.Field.Nodes[0].PrimaryCluster.Id = "FETCH"
     
+            if ( $AsQuery ) { return $query }
             $result = $query.Invoke()
             $result.Nodes
         }

--- a/Toolkit/Public/Get-RscNasShare.ps1
+++ b/Toolkit/Public/Get-RscNasShare.ps1
@@ -25,7 +25,9 @@ function Get-RscNasShare {
     The object representing the NAS system.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Retrieve list of NAS shares.

--- a/Toolkit/Public/Get-RscNasSystem.ps1
+++ b/Toolkit/Public/Get-RscNasSystem.ps1
@@ -22,7 +22,9 @@ function Get-RscNasSystem {
     Switch to list all NAS systems.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Retrieve list of NAS systems.

--- a/Toolkit/Public/Get-RscNutanixVm.ps1
+++ b/Toolkit/Public/Get-RscNutanixVm.ps1
@@ -11,6 +11,11 @@ function Get-RscNutanixVm {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all VMs
     Get-RscNutanixVm
@@ -49,7 +54,12 @@ function Get-RscNutanixVm {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -64,6 +74,7 @@ function Get-RscNutanixVm {
             $query.Field.AgentStatus = New-Object -TypeName RubrikSecurityCloud.Types.NutanixVmAgentStatus
             $query.Field.AgentStatus.connectionStatus = New-Object -typename RubrikSecurityCloud.Types.NutanixVmAgentConnectionStatus
             $query.Field.osType = New-Object -TypeName RubrikSecurityCloud.Types.OsType
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -104,6 +115,7 @@ function Get-RscNutanixVm {
                 $query.var.filter += $clusterFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscOracleDatabase.ps1
+++ b/Toolkit/Public/Get-RscOracleDatabase.ps1
@@ -11,6 +11,11 @@ function Get-RscOracleDatabase {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscOracleDatabase
@@ -57,7 +62,12 @@ function Get-RscOracleDatabase {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.OracleHost]$OracleHost
+        [RubrikSecurityCloud.Types.OracleHost]$OracleHost,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -68,6 +78,7 @@ function Get-RscOracleDatabase {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -110,6 +121,7 @@ function Get-RscOracleDatabase {
                 $query.var.filter += $OracleHostFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscOracleHost.ps1
+++ b/Toolkit/Public/Get-RscOracleHost.ps1
@@ -11,6 +11,11 @@ function Get-RscOracleHost {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscOracleHost
@@ -44,7 +49,12 @@ function Get-RscOracleHost {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -80,8 +90,9 @@ function Get-RscOracleHost {
             $query.var.filter += $clusterFilter
         }
 
+        if ( $AsQuery ) { return $query }
         $result = Invoke-Rsc -Query $query
         $result.nodes
-    } 
+    }
 }
 

--- a/Toolkit/Public/Get-RscOrganization.ps1
+++ b/Toolkit/Public/Get-RscOrganization.ps1
@@ -11,6 +11,11 @@ function Get-RscOrganization {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all roles
     Get-RscOrganization
@@ -34,7 +39,12 @@ function Get-RscOrganization {
             Mandatory = $false,
             ParameterSetName = "Name"
         )]
-        [String]$Name
+        [String]$Name,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -70,6 +80,7 @@ function Get-RscOrganization {
             # $query.Nodes[0].AllClusterCapacityQuotas = New-Object -TypeName RubrikSecurityCloud.Types.ClusterWithCapacityQuota
             $query.field.CrossAccountCapabilities = @([RubrikSecurityCloud.Types.CrossAccountCapability]::CROSS_ACCOUNT_CAPABILITY_UNSPECIFIED)
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -108,8 +119,9 @@ function Get-RscOrganization {
             # $query.Nodes[0].AllClusterCapacityQuotas = New-Object -TypeName RubrikSecurityCloud.Types.ClusterWithCapacityQuota
             $query.field.Nodes[0].CrossAccountCapabilities = @([RubrikSecurityCloud.Types.CrossAccountCapability]::CROSS_ACCOUNT_CAPABILITY_UNSPECIFIED)
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }
-    } 
+    }
 }

--- a/Toolkit/Public/Get-RscRole.ps1
+++ b/Toolkit/Public/Get-RscRole.ps1
@@ -11,6 +11,11 @@ function Get-RscRole {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all roles
     Get-RscRole
@@ -34,7 +39,12 @@ function Get-RscRole {
             Mandatory = $false,
             ParameterSetName = "Name"
         )]
-        [String]$Name
+        [String]$Name,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -42,6 +52,7 @@ function Get-RscRole {
         if ($Id) {
             $query = New-RscQuery -GqlQuery getRolesByIds -FieldProfile FULL
             $query.var.roleIds = $Id
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -49,8 +60,9 @@ function Get-RscRole {
             if ($Name) {
                 $query.var.nameFilter = $Name
             }
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }
-    } 
+    }
 }

--- a/Toolkit/Public/Get-RscSapHanaDatabase.ps1
+++ b/Toolkit/Public/Get-RscSapHanaDatabase.ps1
@@ -11,6 +11,11 @@ function Get-RscSapHanaDatabase {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscSapHanaDatabase
@@ -56,7 +61,12 @@ function Get-RscSapHanaDatabase {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.SapHanaSystem]$SapHanaSystem
+        [RubrikSecurityCloud.Types.SapHanaSystem]$SapHanaSystem,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -67,6 +77,7 @@ function Get-RscSapHanaDatabase {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -109,6 +120,7 @@ function Get-RscSapHanaDatabase {
                 $query.var.filter += $SapHanaSystemFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscSapHanaSystem.ps1
+++ b/Toolkit/Public/Get-RscSapHanaSystem.ps1
@@ -11,6 +11,11 @@ function Get-RscSapHanaSystem {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all
     Get-RscSapHanaSystem
@@ -49,9 +54,14 @@ function Get-RscSapHanaSystem {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Cluster]$Cluster
+        [RubrikSecurityCloud.Types.Cluster]$Cluster,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
-    
+
     Process {
 
        # The query is different for getting a single object by ID.
@@ -60,6 +70,7 @@ function Get-RscSapHanaSystem {
             $query.var.filter = @()
             $query.Var.fid = $Id
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -95,6 +106,7 @@ function Get-RscSapHanaSystem {
                 $query.var.filter += $clusterFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }

--- a/Toolkit/Public/Get-RscSnapshot.ps1
+++ b/Toolkit/Public/Get-RscSnapshot.ps1
@@ -11,6 +11,11 @@ function Get-RscSnapshot {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get snapshots for a specific VM
     Get-RscVmwareVm -Name "jake-001" | Get-RscSnapshot
@@ -56,7 +61,12 @@ function Get-RscSnapshot {
             ValueFromPipeline = $false,
             ParameterSetName = "Object"
         )]
-        [switch]$Latest
+        [switch]$Latest,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
 
     )
     
@@ -157,6 +167,7 @@ function Get-RscSnapshot {
             $polarisSnapshotQuery = New-RscQuery -GqlQuery polarisSnapshot
             $polarisSnapshotQuery.var.snapshotFid = $Id
             $polarisSnapshotQuery.field = $polarisSnapshotFieldDef
+            if ( $AsQuery ) { return $polarisSnapshotQuery }
             $result = snapshotById($polarisSnapshotQuery)
             if ($null -ne $result) {
                 return $result
@@ -219,8 +230,9 @@ function Get-RscSnapshot {
             # CDM snapshot type
             $query.field.nodes[$cdmSnapshot] = $cdmSnapshotFieldDef
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
-        }    
+        }
     }
 } 

--- a/Toolkit/Public/Get-RscVmwareVm.ps1
+++ b/Toolkit/Public/Get-RscVmwareVm.ps1
@@ -11,6 +11,11 @@ function Get-RscVmwareVm {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all VMs
     Get-RscVmwareVm
@@ -70,7 +75,12 @@ function Get-RscVmwareVm {
             ValueFromPipeline = $true,
             ParameterSetName = "Name"
         )]
-        [RubrikSecurityCloud.Types.Org]$Org
+        [RubrikSecurityCloud.Types.Org]$Org,
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -97,6 +107,7 @@ function Get-RscVmwareVm {
             $query.Field.allOrgs = New-Object RubrikSecurityCloud.Types.Org
             $query.Field.allOrgs[0].name = "FETCH"
             $query.Field.allOrgs[0].id = "FETCH"
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result
         } else {
@@ -163,8 +174,9 @@ function Get-RscVmwareVm {
                 $query.var.filter += $replicaFilter
             }
 
+            if ( $AsQuery ) { return $query }
             $result = Invoke-Rsc -Query $query
             $result.nodes
         }
-    } 
+    }
 }

--- a/Toolkit/Public/Get-RscWorkload.ps1
+++ b/Toolkit/Public/Get-RscWorkload.ps1
@@ -11,6 +11,11 @@ function Get-RscWorkload {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Get all Workloads
     Get-RscWorkload

--- a/Toolkit/Public/New-RscMssqlExport.ps1
+++ b/Toolkit/Public/New-RscMssqlExport.ps1
@@ -66,6 +66,11 @@ function New-RscMssqlExport{
     In general, the default value of 2 performs best. However in some cases, increasing the value can provide better performance of the restore. Do not change this value in a
     production setting without running some tests in a non-production environment. 
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Exports a database using the latest recovery point using the "Simple Method"
     This means you provide a single data and log path for all data and log files to go into. This does not allow for the 
@@ -163,7 +168,13 @@ function New-RscMssqlExport{
         [ValidateRange(1, 8)]
         [Parameter(
             Mandatory = $false
-        )][int]$MaxDataStreams = 2
+        )][int]$MaxDataStreams = 2,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -201,6 +212,7 @@ function New-RscMssqlExport{
         $query.Var.input.Config.targetInstanceId = $TargetMssqlInstance.Id
         #endregion
 
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/New-RscMssqlLiveMount.ps1
+++ b/Toolkit/Public/New-RscMssqlLiveMount.ps1
@@ -23,6 +23,11 @@ function New-RscMssqlLiveMount {
     .PARAMETER TargetMssqlInstance
     SQL Server Instance Object returned from Get-RscMssqlInstance
     
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns the list of database files based on the latest recovery point
     
@@ -47,7 +52,13 @@ function New-RscMssqlLiveMount {
        
         [Parameter(
             Mandatory = $true
-        )][datetime]$RecoveryDateTime
+        )][datetime]$RecoveryDateTime,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -63,6 +74,7 @@ function New-RscMssqlLiveMount {
         $query.Var.input.config.recoveryPoint.date = $RecoveryDateTime
         $query.Var.input.config.targetInstanceId = "$($TargetMssqlInstance.Id)"
 
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/New-RscMssqlLogBackup.ps1
+++ b/Toolkit/Public/New-RscMssqlLogBackup.ps1
@@ -14,6 +14,11 @@ function New-RscMssqlLogBackup {
     .PARAMETER RscMssqlDatabase
     Database object returned from Get-RscMssqlDatabase
     
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Returns the list of database files based on the latest recovery point
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
@@ -24,10 +29,17 @@ function New-RscMssqlLogBackup {
     )]
     Param(
         [Parameter(
-            Mandatory = $false, 
+            Mandatory = $false,
             ValueFromPipeline = $true
         )]
-        [RubrikSecurityCloud.Types.MssqlDatabase]$RscMssqlDatabase
+        [RubrikSecurityCloud.Types.MssqlDatabase]$RscMssqlDatabase,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )]
+        [Switch]$AsQuery
     )
     Process {
         Write-Debug "- Running New-RscMssqlLogBackup"
@@ -37,6 +49,7 @@ function New-RscMssqlLogBackup {
         $query.Var.input.id = "$($RscMssqlDatabase.Id)"
         #endregion
         
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/New-RscMssqlLogShippingSecondary.ps1
+++ b/Toolkit/Public/New-RscMssqlLogShippingSecondary.ps1
@@ -46,6 +46,11 @@ function New-RscMssqlLogShippingSecondary{
     .PARAMETER AutomaticReseed
     Automatically reseed the log shipping configuration when the primary transaction log chain breaks
     
+
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
     #>
 
     [CmdletBinding()]
@@ -97,8 +102,13 @@ function New-RscMssqlLogShippingSecondary{
 
         [Parameter(
             Mandatory = $false
-        )][Switch]$AutomaticReseed
+        )][Switch]$AutomaticReseed,
 
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -151,7 +161,8 @@ function New-RscMssqlLogShippingSecondary{
         }        
         #endregion
 
+        if ( $AsQuery ) { return $query }
         $query.Invoke()
-        
-    } 
+
+    }
 }

--- a/Toolkit/Public/New-RscMssqlRestore.ps1
+++ b/Toolkit/Public/New-RscMssqlRestore.ps1
@@ -32,6 +32,11 @@ function New-RscMssqlRestore {
 
     # .PARAMETER RecoveryLSN
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Performs an in-place recovery of AdventureWorks2019 to a specific point in time. 
     $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
@@ -58,7 +63,13 @@ function New-RscMssqlRestore {
 
         [Parameter(
             Mandatory = $true
-        )][datetime]$RecoveryDateTime
+        )][datetime]$RecoveryDateTime,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
 
         # [Parameter(
         #     ParameterSetName = 'Recovery_LSN',
@@ -83,6 +94,7 @@ function New-RscMssqlRestore {
         $query.Var.input.config.recoveryPoint.date = $RecoveryDateTime
         #endregion
         
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/New-RscMssqlSnapshot.ps1
+++ b/Toolkit/Public/New-RscMssqlSnapshot.ps1
@@ -23,6 +23,11 @@ function New-RscMssqlSnapshot {
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Starts an On Demand Snapshot of a MSSQL Database with an SLA Domain ID
     $sla = Get-RscSla -Name "sdf"
@@ -43,9 +48,15 @@ function New-RscMssqlSnapshot {
         )][bool]$ForceFullSnapshot,
         
         [Parameter(
-            Mandatory = $true, 
+            Mandatory = $true,
             ValueFromPipeline = $false
-        )][RubrikSecurityCloud.Types.GlobalSlaReply]$RscSlaDomain
+        )][RubrikSecurityCloud.Types.GlobalSlaReply]$RscSlaDomain,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -64,6 +75,7 @@ function New-RscMssqlSnapshot {
         $query.Var.input.config.baseOnDemandSnapshotConfig.slaId = $RscSlaDomain.Id
         #endregion
         
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/New-RscNasShare.ps1
+++ b/Toolkit/Public/New-RscNasShare.ps1
@@ -21,6 +21,11 @@ function New-RscNasShare {
     .PARAMTER AsQuery
     Instead of running the command, the query object is returned.
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     $createNasShare = New-RscNasShareInput -ShareType NFS -ExportPoint "/test_mounts/100_mb"
     New-RscNasShare -NasSystemId "b951f770-4519-5820-a451-5b2ff4a50f26" -NasShares @($createNasShare)

--- a/Toolkit/Public/New-RscNasSystem.ps1
+++ b/Toolkit/Public/New-RscNasSystem.ps1
@@ -60,7 +60,9 @@ function New-RscNasSystem {
     API token to add or update the Pure NAS system with API integration.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     $cluster = Get-RscCluter -Name "Foo"

--- a/Toolkit/Public/New-RscPermission.ps1
+++ b/Toolkit/Public/New-RscPermission.ps1
@@ -14,6 +14,11 @@ function New-RscPermission
 
 
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Create permission object to take on-demand snapshot of all VMs in the Gold SLA, then merge into a role.
     $permission = Get-RscSla -name "Gold" | Get-RscVmwareVm | New-RscPermission -Operation TAKE_ON_DEMAND_SNAPSHOT
@@ -31,7 +36,13 @@ function New-RscPermission
         [RubrikSecurityCloud.Types.Operation]$Operation,
 
         [Parameter(ValueFromPipeline=$true)]
-        [RubrikSecurityCloud.Types.BaseType[]]$InputObject
+        [RubrikSecurityCloud.Types.BaseType[]]$InputObject,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     Begin {
         $objectIds = @()
@@ -49,6 +60,7 @@ function New-RscPermission
     }
     End {
         $globalResourceQuery = New-RscQuery -GqlQuery allAuthorizationsForGlobalResource
+        if ( $AsQuery ) { return $globalResourceQuery }
         $globalResourceOperations = Invoke-Rsc $globalResourceQuery
 
         $permission = New-Object -TypeName RubrikSecurityCloud.Types.Permission

--- a/Toolkit/Public/New-RscSla.ps1
+++ b/Toolkit/Public/New-RscSla.ps1
@@ -12,6 +12,11 @@ function New-RscSla
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Create a Snapshot schedule to take a snapshot every 1 hour and retain that snapshot for 7 days. Then create the SLA Domain with that schedule.
     
@@ -132,7 +137,13 @@ function New-RscSla
     
     # Postgres Db Cluster specific settings of this SLA.
     [Parameter()]
-    [RubrikSecurityCloud.Types.PostgresDbClusterSlaConfigInput]$PostgresDbClusterConfig
+    [RubrikSecurityCloud.Types.PostgresDbClusterSlaConfigInput]$PostgresDbClusterConfig,
+
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipeline = $false,
+        HelpMessage = "Return the query object instead of running the query"
+    )][Switch]$AsQuery
   )
     Process {
 
@@ -225,6 +236,7 @@ function New-RscSla
         }
         $query.Var.Input.ObjectSpecificConfigsInput = $objectSpecificConfig
 
+        if ( $AsQuery ) { return $query }
         $result = Invoke-Rsc -Query $query
         $result
     }

--- a/Toolkit/Public/Protect-RscLinkedWorkload.ps1
+++ b/Toolkit/Public/Protect-RscLinkedWorkload.ps1
@@ -12,6 +12,11 @@ function Protect-RscLinkedWorkload
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     $ag1 = Get-RscMssqlAvailabilityGroup -AvailabilityGroupName "Foo" -Cluster (Get-RscCluster -Name "Bar") -Relic:$false -Replica:$false
     $ag2 = Get-RscMssqlAvailabilityGroup -AvailabilityGroupName "Foo" -Cluster (Get-RscCluster -Name "Baz") -Relic:$false -Replica:$false

--- a/Toolkit/Public/Protect-RscWorkload.ps1
+++ b/Toolkit/Public/Protect-RscWorkload.ps1
@@ -12,6 +12,11 @@ function Protect-RscWorkload
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Assign a VM named "foo" to the Gold SLA
     
@@ -61,7 +66,13 @@ function Protect-RscWorkload
 
     # RSC Snapshot retention setting
     [Parameter()]
-    [RubrikSecurityCloud.Types.GlobalExistingSnapshotRetention]$ExistingSnapshotAction
+    [RubrikSecurityCloud.Types.GlobalExistingSnapshotRetention]$ExistingSnapshotAction,
+
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipeline = $false,
+        HelpMessage = "Return the query object instead of running the query"
+    )][Switch]$AsQuery
   )
     Process {
 
@@ -89,6 +100,7 @@ function Protect-RscWorkload
           $query.Var.Input.ShouldApplyToNonPolicySnapshots = "true"
         }
         
+        if ( $AsQuery ) { return $query }
         $result = Invoke-Rsc -Query $query
         $result
     }

--- a/Toolkit/Public/Register-RscRubrikBackupService.ps1
+++ b/Toolkit/Public/Register-RscRubrikBackupService.ps1
@@ -24,6 +24,11 @@ function Register-RscRubrikBackupService
     .PARAMETER Async
     Register physical host using async mutation
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Register RBS on a VMware VM
     Get-RscVmwareVm -Name "jake-001" | Register-RscRubrikBackupService
@@ -57,10 +62,16 @@ function Register-RscRubrikBackupService
         [RubrikSecurityCloud.Types.Cluster]$Cluster,
 
         # Async option.
-        [Parameter(Mandatory=$false, 
+        [Parameter(Mandatory=$false,
         ParameterSetName = "host",
         ValueFromPipeline=$false)]
-        [switch]$Async
+        [switch]$Async,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
 
     )
 
@@ -105,6 +116,7 @@ function Register-RscRubrikBackupService
             $query.var.input.clusterUuid = $Cluster.Id
         }
         
+        if ( $AsQuery ) { return $query }
         try {
             Invoke-Rsc $query
         }

--- a/Toolkit/Public/Remove-RscMssqlLiveMount.ps1
+++ b/Toolkit/Public/Remove-RscMssqlLiveMount.ps1
@@ -14,7 +14,9 @@ function Remove-RscMssqlLiveMount {
     Forces the unmount of a database in the event Rubrik cannot connect to the SQL Server Instance or database. 
 
     .PARAMETER AsQuery
-    Instead of running the command, the query and variables used for the query will be returned. 
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Removes the live mount from the SQL Server and cleans up the share and files on the Rubrik cluster
@@ -39,10 +41,17 @@ function Remove-RscMssqlLiveMount {
         [RubrikSecurityCloud.Types.MssqlDatabaseLiveMount]$MssqlLiveMount, 
 
         [Parameter(
-            Mandatory = $false, 
+            Mandatory = $false,
             ValueFromPipelineByPropertyName = $false
         )]
-        [Switch]$Force
+        [Switch]$Force,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )]
+        [Switch]$AsQuery
     )
     
     Process {
@@ -56,6 +65,7 @@ function Remove-RscMssqlLiveMount {
         $query.Var.input.force = $force
 
         #endregion
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/Remove-RscMssqlLogShippingSecondary.ps1
+++ b/Toolkit/Public/Remove-RscMssqlLogShippingSecondary.ps1
@@ -13,6 +13,11 @@ function Remove-RscMssqlLogShippingSecondary {
     .PARAMETER deleteSecondaryDatabase
     Switch to delete the database off of the secondary host
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Removes the live mount from the SQL Server and cleans up the share and files on the Rubrik cluster
     $GetRscMssqlLogShipping = @{
@@ -40,10 +45,17 @@ function Remove-RscMssqlLogShippingSecondary {
         [RubrikSecurityCloud.Types.MssqlLogShippingTarget]$RscMssqlLogShipping,
 
         [Parameter(
-            Mandatory = $false, 
+            Mandatory = $false,
             ValueFromPipelineByPropertyName = $false
         )]
-        [Switch]$deleteSecondaryDatabase
+        [Switch]$deleteSecondaryDatabase,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )]
+        [Switch]$AsQuery
     )
     
     Process {
@@ -56,6 +68,7 @@ function Remove-RscMssqlLogShippingSecondary {
         $query.Var.input.deleteSecondaryDatabase = $deleteSecondaryDatabase
 
         #endregion
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/Remove-RscNasShare.ps1
+++ b/Toolkit/Public/Remove-RscNasShare.ps1
@@ -18,7 +18,9 @@ function Remove-RscNasShare {
     The objects representing NAS shares to be deleted.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Remove-RscNasShare -Ids @("b951f770-4519-5820-a451-5b2ff4a50f26", "b951f770-4519-5820-a451-5b2ff4a50f27")

--- a/Toolkit/Public/Remove-RscNasSystem.ps1
+++ b/Toolkit/Public/Remove-RscNasSystem.ps1
@@ -18,7 +18,9 @@ function Remove-RscNasSystem {
     The object representing the NAS system to be deleted.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Remove-RscNasSystem "b951f770-4519-5820-a451-5b2ff4a50f25"

--- a/Toolkit/Public/Remove-RscSla.ps1
+++ b/Toolkit/Public/Remove-RscSla.ps1
@@ -26,7 +26,9 @@ function Remove-RscSla {
     RSC.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Delete an SLA with the given SLA id and usernote

--- a/Toolkit/Public/Resume-RscSla.ps1
+++ b/Toolkit/Public/Resume-RscSla.ps1
@@ -27,7 +27,9 @@ function Resume-RscSla {
     The Global Sla which should be resumed.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Resume an SLA on two clusters on which it is applied.

--- a/Toolkit/Public/Set-RscMssqlDatabase.ps1
+++ b/Toolkit/Public/Set-RscMssqlDatabase.ps1
@@ -94,6 +94,11 @@ function Set-RscMssqlDatabase {
     .PARAMETER RemovePostBackupScript
     Removes the Post Script values
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     Set-RscMssqlDatabase -RscMssqlDatabase $RscMssqlDatabase -RscCluster $RscCluster -RscSlaDomain $RscSlaDomain
     #>
@@ -201,7 +206,13 @@ function Set-RscMssqlDatabase {
         [Switch]$RemovePreBackupScript,
 
         [Parameter(ParameterSetName = "Remove Post-BackupScript", Mandatory = $true)]
-        [Switch]$RemovePostBackupScript
+        [Switch]$RemovePostBackupScript,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     Process {
         Write-Debug "- Running Set-RscMssqlDatabase"
@@ -389,6 +400,7 @@ function Set-RscMssqlDatabase {
             Default {}
         }
         #endregion
+        if ( $AsQuery ) { return $query }
         $query.Invoke()
-    } 
+    }
 }

--- a/Toolkit/Public/Set-RscMssqlLogShippingSecondary.ps1
+++ b/Toolkit/Public/Set-RscMssqlLogShippingSecondary.ps1
@@ -14,7 +14,9 @@ function Set-RscMssqlLogShippingSecondary {
     Forces the unmount of a database in the event Rubrik cannot connect to the SQL Server Instance or database. 
 
     .PARAMETER AsQuery
-    Instead of running the command, the query and variables used for the query will be returned. 
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Removes the live mount from the SQL Server and cleans up the share and files on the Rubrik cluster
@@ -39,10 +41,17 @@ function Set-RscMssqlLogShippingSecondary {
         [RubrikSecurityCloud.Types.MssqlLogShippingTarget]$RscMssqlLogShipping, 
 
         [Parameter(
-            Mandatory = $false, 
+            Mandatory = $false,
             ValueFromPipelineByPropertyName = $false
         )]
-        [Switch]$Force
+        [Switch]$Force,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )]
+        [Switch]$AsQuery
     )
     
     Process {
@@ -56,6 +65,7 @@ function Set-RscMssqlLogShippingSecondary {
         $query.Var.input.force = $force
 
         #endregion
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/Set-RscNasShare.ps1
+++ b/Toolkit/Public/Set-RscNasShare.ps1
@@ -16,8 +16,10 @@ function Set-RscNasShare {
     The list of NAS shares to be updated. Create input objects using New-RscNasShareInput.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
-    
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     $updatedNasShare = New-RscNasShareInput -ExportPoint "/test_mounts/100_mb"
     -NasShareId "d93ddffc-5a70-53f4-9cfa-be54ebeaa5cb"

--- a/Toolkit/Public/Set-RscNasSystem.ps1
+++ b/Toolkit/Public/Set-RscNasSystem.ps1
@@ -50,7 +50,9 @@ function Set-RscNasSystem {
     in namespaces and recreate them.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Set-RscNasSystem "5dc44746-38d1-56d8-8570-a54b8dae0208"

--- a/Toolkit/Public/Set-RscRole.ps1
+++ b/Toolkit/Public/Set-RscRole.ps1
@@ -12,6 +12,11 @@ function Set-RscRole
     Schema reference:
     https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
 
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     # Update the description of a role
     
@@ -39,7 +44,13 @@ function Set-RscRole
 
     # RSC Sla Object
     [Parameter(ValueFromPipeline=$true)]
-    [RubrikSecurityCloud.Types.Role]$Role
+    [RubrikSecurityCloud.Types.Role]$Role,
+
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipeline = $false,
+        HelpMessage = "Return the query object instead of running the query"
+    )][Switch]$AsQuery
 
   )
     Process {
@@ -52,6 +63,7 @@ function Set-RscRole
         $query.Var.permissions = $Role.Permissions
         $query.Var.protectableClusters = $role.ProtectableClusters
         
+        if ( $AsQuery ) { return $query }
         $result = Invoke-Rsc -Query $query
         $result
     }

--- a/Toolkit/Public/Set-RscSla.ps1
+++ b/Toolkit/Public/Set-RscSla.ps1
@@ -121,7 +121,9 @@ function Set-RscSla
     Postgres Db Cluster specific settings of this SLA.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     The example below updates the SLA Domain with the ID

--- a/Toolkit/Public/Start-RscManagedVolumeSnapshot.ps1
+++ b/Toolkit/Public/Start-RscManagedVolumeSnapshot.ps1
@@ -14,6 +14,11 @@ function Start-RscManagedVolumeSnapshot {
     .PARAMETER RscManagedVolume
     Managed Volume Object as retrieved from Get-RscManagedVolume
    
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     $RscManagedVolume = Get-RscManagedVolume -Name rp-mysql-01
     Start-RscManagedVolumeSnapshot -RscManagedVolume $RscManagedVolume
@@ -22,10 +27,17 @@ function Start-RscManagedVolumeSnapshot {
     [CmdletBinding()]
     Param(
         [Parameter(
-            Mandatory = $true, 
+            Mandatory = $true,
             ValueFromPipeline = $true
         )]
-        [RubrikSecurityCloud.Types.ManagedVolume]$RscManagedVolume
+        [RubrikSecurityCloud.Types.ManagedVolume]$RscManagedVolume,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )]
+        [Switch]$AsQuery
     )
     
     Process {
@@ -38,6 +50,7 @@ function Start-RscManagedVolumeSnapshot {
         $query.Var.input.config.isAsync = $true
 
         #endregion
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/Stop-RscManagedVolumeSnapshot.ps1
+++ b/Toolkit/Public/Stop-RscManagedVolumeSnapshot.ps1
@@ -18,6 +18,11 @@ function Stop-RscManagedVolumeSnapshot {
     .PARAMETER RscSlaDomain
     SLA Domain Object as retrieved from Get-RscSlaDomain
     
+    .PARAMETER AsQuery
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
+
     .EXAMPLE
     $RscManagedVolume = Get-RscManagedVolume -Name rp-mysql-01
     Stop-RscManagedVolumeSnapshot -RscManagedVolume $RscManagedVolume -SlaDomainId $RscManagedVolume.EffectiveSlaDomain.Id
@@ -32,9 +37,15 @@ function Stop-RscManagedVolumeSnapshot {
         [RubrikSecurityCloud.Types.ManagedVolume]$RscManagedVolume,
 
         [Parameter(
-            Mandatory = $true, 
+            Mandatory = $true,
             ValueFromPipeline = $false
-        )][RubrikSecurityCloud.Types.GlobalSlaReply]$RscSlaDomain
+        )][RubrikSecurityCloud.Types.GlobalSlaReply]$RscSlaDomain,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $false,
+            HelpMessage = "Return the query object instead of running the query"
+        )][Switch]$AsQuery
     )
     
     Process {
@@ -50,6 +61,7 @@ function Stop-RscManagedVolumeSnapshot {
         $query.Var.input.params.retentionConfig.slaId = $RscSlaDomain.Id
         #endregion
 
+        if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
     } 

--- a/Toolkit/Public/Suspend-RscSla.ps1
+++ b/Toolkit/Public/Suspend-RscSla.ps1
@@ -27,7 +27,9 @@ function Suspend-RscSla {
     The Global Sla which should be suspended.
 
     .PARAMETER AsQuery
-    Instead of running the command, the query object is returned.
+    Return the query object instead of running the query.
+    Preliminary read-only queries may still run to gather IDs or
+    other data needed to build the main query.
 
     .EXAMPLE
     Suspend an SLA on two clusters on which it is applied.

--- a/Toolkit/Tests/unit/AsQuery.Tests.ps1
+++ b/Toolkit/Tests/unit/AsQuery.Tests.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+Verify that all exported commands with an -AsQuery parameter
+return an [RubrikSecurityCloud.RscQuery] object (or array of them).
+
+Commands with mandatory parameters are tested with mock objects.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name "AsQuery Parameter Tests" -Fixture {
+
+    It -Name 'At least 60 commands have -AsQuery' -Test {
+        $commands = Get-Command -Module RubrikSecurityCloud |
+            Where-Object { $_.Parameters.ContainsKey('AsQuery') }
+        $commands.Count | Should -BeGreaterOrEqual 60
+    }
+
+    BeforeAll {
+        # Build mock objects for mandatory parameters.
+        # These don't need valid data — -AsQuery returns
+        # the query object before any API call.
+        $mockMssqlDb = New-Object RubrikSecurityCloud.Types.MssqlDatabase
+        $mockMssqlInstance = New-Object RubrikSecurityCloud.Types.MssqlInstance
+        $mockSla = New-Object RubrikSecurityCloud.Types.GlobalSlaReply
+        $mockCluster = New-Object RubrikSecurityCloud.Types.Cluster
+        $mockManagedVolume = New-Object RubrikSecurityCloud.Types.ManagedVolume
+        $mockRole = New-Object RubrikSecurityCloud.Types.Role
+        $mockVm = New-Object RubrikSecurityCloud.Types.VsphereVm
+        $mockNasShareInput = @(New-Object RubrikSecurityCloud.Types.CreateNasShareInput)
+        $mockUpdateNasShareInput = @(New-Object RubrikSecurityCloud.Types.UpdateNasShareInput)
+        $mockLiveMount = New-Object RubrikSecurityCloud.Types.MssqlDatabaseLiveMount
+        $mockLogShipping = New-Object RubrikSecurityCloud.Types.MssqlLogShippingTarget
+        $mockNasSystem = New-Object RubrikSecurityCloud.Types.NasSystem
+        $mockNasSystem.VendorType = [RubrikSecurityCloud.Types.NasVendorType]::GENERIC
+
+        # Mock params for commands that need mandatory arguments.
+        $mockParams = @{
+            'Get-RscCloudNativeTagRule'              = @{ ObjectType = [RubrikSecurityCloud.Types.CloudNativeTagObjectType]::AWS_EBS_VOLUME }
+            'Get-RscMssqlDatabaseFiles'              = @{ RscMssqlDatabase = $mockMssqlDb; RecoveryDateTime = [datetime]'2024-01-01' }
+            'Get-RscMssqlDatabaseRecoverableRanges'  = @{ RscMssqlDatabase = $mockMssqlDb }
+            'Get-RscMssqlDatabaseRecoveryPoint'      = @{ RscMssqlDatabase = $mockMssqlDb; Latest = $true }
+            'Get-RscSnapshot'                        = @{ Id = '00000000-0000-0000-0000-000000000000' }
+            'New-RscMssqlExport'                     = @{ RscMssqlDatabase = $mockMssqlDb; RecoveryDateTime = [datetime]'2024-01-01'; TargetMssqlInstance = $mockMssqlInstance; TargetDatabaseName = 'mock'; TargetDataPath = 'c:\data'; TargeLogPath = 'c:\log' }
+            'New-RscMssqlLiveMount'                  = @{ RscMssqlDatabase = $mockMssqlDb; MountedDatabaseName = 'mock'; TargetMssqlInstance = $mockMssqlInstance; RecoveryDateTime = [datetime]'2024-01-01' }
+            'New-RscMssqlLogBackup'                  = @{ RscMssqlDatabase = $mockMssqlDb }
+            'New-RscMssqlLogShippingSecondary'       = @{ RscMssqlDatabase = $mockMssqlDb; TargetMssqlInstance = $mockMssqlInstance; TargetDatabaseName = 'mock'; State = 'RESTORING'; TargetDataPath = 'c:\data'; TargeLogPath = 'c:\log' }
+            'New-RscMssqlRestore'                    = @{ RscMssqlDatabase = $mockMssqlDb; RecoveryDateTime = [datetime]'2024-01-01' }
+            'New-RscMssqlSnapshot'                   = @{ RscMssqlDatabase = $mockMssqlDb; RscSlaDomain = $mockSla }
+            'New-RscNasShare'                        = @{ NasSystemId = '00000000-0000-0000-0000-000000000000'; NasShares = $mockNasShareInput }
+            'New-RscNasSystem'                       = @{ Cluster = $mockCluster; Hostname = 'mock-host'; Generic = $true }
+            'New-RscPermission'                      = @{ Operation = [RubrikSecurityCloud.Types.Operation]::VIEW_CLUSTER }
+            'New-RscSla'                             = @{ Name = 'mock-sla'; ObjectType = [RubrikSecurityCloud.Types.SlaObjectType]::VSPHERE_OBJECT_TYPE }
+            'Protect-RscLinkedWorkload'              = @{ InputObject = $mockVm; AssignmentType = [RubrikSecurityCloud.Types.SlaAssignTypeEnum]::PROTECT_WITH_SLA_ID; LinkedObject = $mockVm; LinkingOperation = [RubrikSecurityCloud.Types.ManageProtectionForLinkedObjectsOperationType]::LINK }
+            'Register-RscRubrikBackupService'        = @{ VM = $mockVm }
+            'Remove-RscMssqlLiveMount'               = @{ MssqlLiveMount = $mockLiveMount }
+            'Remove-RscMssqlLogShippingSecondary'    = @{ RscMssqlLogShipping = $mockLogShipping }
+            'Remove-RscNasShare'                     = @{ Ids = @('00000000-0000-0000-0000-000000000000') }
+            'Remove-RscNasSystem'                    = @{ Id = '00000000-0000-0000-0000-000000000000' }
+            'Remove-RscSla'                          = @{ GlobalSla = $mockSla }
+            'Resume-RscSla'                          = @{ ClusterUuids = @('00000000-0000-0000-0000-000000000000'); GlobalSla = $mockSla }
+            'Set-RscMssqlDatabase'                   = @{ RscMssqlDatabase = $mockMssqlDb; RscCluster = $mockCluster; RemovePreBackupScript = $true }
+            'Set-RscMssqlLogShippingSecondary'       = @{ RscMssqlLogShipping = $mockLogShipping }
+            'Set-RscNasShare'                        = @{ NasShares = $mockUpdateNasShareInput }
+            'Set-RscNasSystem'                       = @{ NasSystem = $mockNasSystem }
+            'Set-RscRole'                            = @{ Role = $mockRole }
+            'Start-RscManagedVolumeSnapshot'         = @{ RscManagedVolume = $mockManagedVolume }
+            'Stop-RscManagedVolumeSnapshot'          = @{ RscManagedVolume = $mockManagedVolume; RscSlaDomain = $mockSla }
+            'Suspend-RscSla'                         = @{ ClusterUuids = @('00000000-0000-0000-0000-000000000000'); GlobalSla = $mockSla }
+        }
+
+        # All commands with -AsQuery
+        $allCommands = Get-Command -Module RubrikSecurityCloud |
+            Where-Object { $_.Parameters.ContainsKey('AsQuery') }
+    }
+
+    It -Name 'All -AsQuery commands return RscQuery objects' -Test {
+        $failures = @()
+        foreach ($cmd in $allCommands) {
+            try {
+                $params = @{ AsQuery = $true }
+                if ($mockParams.ContainsKey($cmd.Name)) {
+                    foreach ($kv in $mockParams[$cmd.Name].GetEnumerator()) {
+                        $params[$kv.Key] = $kv.Value
+                    }
+                }
+                $result = & $cmd.Name @params
+                if ($result -is [System.Array]) {
+                    foreach ($item in $result) {
+                        if ($item -isnot [RubrikSecurityCloud.RscQuery]) {
+                            $failures += "$($cmd.Name): array element is $($item.GetType().FullName)"
+                        }
+                    }
+                } elseif ($null -eq $result) {
+                    $failures += "$($cmd.Name): returned null"
+                } else {
+                    if ($result -isnot [RubrikSecurityCloud.RscQuery]) {
+                        $failures += "$($cmd.Name): returned $($result.GetType().FullName)"
+                    }
+                }
+            } catch {
+                $failures += "$($cmd.Name): threw exception: $_"
+            }
+        }
+
+        if ($failures.Count -gt 0) {
+            $msg = "$($failures.Count) command(s) failed:`n" + ($failures -join "`n")
+            $msg | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug fix**: `Get-RscCluster -Count -AsQuery` now returns the query object instead of executing and returning the count (the `-Count` branch was invoking before the `-AsQuery` check)
- **Add `-AsQuery`** to 43 Toolkit scripts that were missing it, bringing coverage from 21/63 to **63/63** API-calling scripts
- **Standardize** `.PARAMETER AsQuery` help text across all 63 scripts
- **Add unit test** (`AsQuery.Tests.ps1`) that verifies all commands with `-AsQuery` return `RscQuery` objects

### Design decisions
- `-AsQuery` returns the *main* query object. Preliminary read-only queries (e.g. ID lookups) may still run.
- `Get-RscAccount -AsQuery` returns `@($q1, $q2)` since it combines two independent queries.

## Test plan
- [x] `make clean build` — 0 errors
- [x] Unit tests pass (`./Utils/Test-RscSdk.ps1 -SkipCoreTests -SkipE2ETests` — 4/4)
- [x] E2E tests pass (`./Utils/Test-RscSdk.ps1 -SkipCoreTests -SkipUnitTests` — 32/32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)