### PR TITLE
Fix Get-RscArchivalLocation returning empty for non-cloud-native targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,4 @@ Output.Release/
 
 # Claude / MCP
 .mcp.json
+.plans

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/StripFieldsTests.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/StripFieldsTests.cs
@@ -197,7 +197,7 @@ namespace RubrikSecurityCloud.Tests
         public void NullQueryReturnsNull()
         {
             string result = StringUtils.StripFieldsFromQuery(
-                null, new HashSet<string> { "x" });
+                null!, new HashSet<string> { "x" });
             Assert.IsNull(result);
         }
 

--- a/Toolkit/Public/Get-RscArchivalLocation.ps1
+++ b/Toolkit/Public/Get-RscArchivalLocation.ps1
@@ -25,6 +25,11 @@ function Get-RscArchivalLocation {
     .PARAMETER Name
     Filter by name. Matches archival locations whose name contains the specified string.
 
+    .PARAMETER GroupType
+    Filter by archival group type. If not specified, all group types are returned.
+    Valid values: CLOUD_NATIVE_ARCHIVAL_GROUP, DATACENTER_ARCHIVAL_GROUP,
+    AUTOMATIC_ARCHIVAL_GROUP, MANUAL_ARCHIVAL_GROUP.
+
     .EXAMPLE
     # Get all archival locations
     Get-RscArchivalLocation
@@ -32,6 +37,10 @@ function Get-RscArchivalLocation {
     .EXAMPLE
     # Get archival locations matching a name
     Get-RscArchivalLocation -Name "S3-Production"
+
+    .EXAMPLE
+    # Get only cloud-native archival locations
+    Get-RscArchivalLocation -GroupType CLOUD_NATIVE_ARCHIVAL_GROUP
 
     .EXAMPLE
     # Get a specific archival location by ID
@@ -52,6 +61,17 @@ function Get-RscArchivalLocation {
             ParameterSetName = "Name"
         )]
         [String]$Name,
+        [Parameter(
+            Mandatory = $false,
+            ParameterSetName = "Name"
+        )]
+        [ValidateSet(
+            "CLOUD_NATIVE_ARCHIVAL_GROUP",
+            "DATACENTER_ARCHIVAL_GROUP",
+            "AUTOMATIC_ARCHIVAL_GROUP",
+            "MANUAL_ARCHIVAL_GROUP"
+        )]
+        [String]$GroupType,
         [Parameter(
             Mandatory = $false,
             ValueFromPipeline = $false,
@@ -82,14 +102,17 @@ function Get-RscArchivalLocation {
         } else {
             $query = New-RscQuery -Gql allTargetMappings
             $query.var.filter = @()
-            $query.var.filter += New-Object -TypeName RubrikSecurityCloud.Types.TargetMappingFilterInput
-            $query.var.filter[0].field = [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::ARCHIVAL_GROUP_TYPE
-            $query.var.filter[0].text = "CLOUD_NATIVE_ARCHIVAL_GROUP"
-
+            if ($GroupType) {
+                $f = New-Object -TypeName RubrikSecurityCloud.Types.TargetMappingFilterInput
+                $f.field = [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::ARCHIVAL_GROUP_TYPE
+                $f.text = $GroupType
+                $query.var.filter += $f
+            }
             if ($Name) {
-                $query.var.filter += New-Object -TypeName RubrikSecurityCloud.Types.TargetMappingFilterInput
-                $query.var.filter[1].field = [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::NAME
-                $query.var.filter[1].text = $Name
+                $f = New-Object -TypeName RubrikSecurityCloud.Types.TargetMappingFilterInput
+                $f.field = [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::NAME
+                $f.text = $Name
+                $query.var.filter += $f
             }
 
             Set-MappingFields $query.Field[0]

--- a/Toolkit/Tests/unit/Get-RscArchivalLocation.Tests.ps1
+++ b/Toolkit/Tests/unit/Get-RscArchivalLocation.Tests.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+Tests for Get-RscArchivalLocation GroupType filtering.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name "Get-RscArchivalLocation Tests" -Fixture {
+
+    It 'no -GroupType: no ARCHIVAL_GROUP_TYPE filter in variables' {
+        $q = Get-RscArchivalLocation -AsQuery
+        $groupFilter = $q.var.filter | Where-Object {
+            $_.field -eq [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::ARCHIVAL_GROUP_TYPE
+        }
+        $groupFilter | Should -BeNullOrEmpty
+    }
+
+    It '-GroupType CLOUD_NATIVE_ARCHIVAL_GROUP: filter is set correctly' {
+        $q = Get-RscArchivalLocation -GroupType CLOUD_NATIVE_ARCHIVAL_GROUP -AsQuery
+        $groupFilter = $q.var.filter | Where-Object {
+            $_.field -eq [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::ARCHIVAL_GROUP_TYPE
+        }
+        $groupFilter | Should -Not -BeNullOrEmpty
+        $groupFilter.text | Should -Be "CLOUD_NATIVE_ARCHIVAL_GROUP"
+    }
+
+    It '-GroupType DATACENTER_ARCHIVAL_GROUP: filter is set correctly' {
+        $q = Get-RscArchivalLocation -GroupType DATACENTER_ARCHIVAL_GROUP -AsQuery
+        $groupFilter = $q.var.filter | Where-Object {
+            $_.field -eq [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::ARCHIVAL_GROUP_TYPE
+        }
+        $groupFilter | Should -Not -BeNullOrEmpty
+        $groupFilter.text | Should -Be "DATACENTER_ARCHIVAL_GROUP"
+    }
+
+    It '-Name filter works independently of -GroupType' {
+        $q = Get-RscArchivalLocation -Name "S3-Prod" -AsQuery
+        $nameFilter = $q.var.filter | Where-Object {
+            $_.field -eq [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::NAME
+        }
+        $nameFilter | Should -Not -BeNullOrEmpty
+        $nameFilter.text | Should -Be "S3-Prod"
+        # No group type filter
+        $groupFilter = $q.var.filter | Where-Object {
+            $_.field -eq [RubrikSecurityCloud.Types.TargetMappingQueryFilterField]::ARCHIVAL_GROUP_TYPE
+        }
+        $groupFilter | Should -BeNullOrEmpty
+    }
+
+    It '-Name and -GroupType can be combined' {
+        $q = Get-RscArchivalLocation -Name "S3-Prod" -GroupType CLOUD_NATIVE_ARCHIVAL_GROUP -AsQuery
+        $q.var.filter.Count | Should -Be 2
+    }
+}


### PR DESCRIPTION
## Summary
- `Get-RscArchivalLocation` hardcoded a `CLOUD_NATIVE_ARCHIVAL_GROUP` filter, excluding datacenter NFS, tape, and other non-cloud-native archive targets
- Removed the hardcoded filter so all archival group types are returned by default
- Added a `-GroupType` parameter (`CLOUD_NATIVE_ARCHIVAL_GROUP`, `DATACENTER_ARCHIVAL_GROUP`, `AUTOMATIC_ARCHIVAL_GROUP`, `MANUAL_ARCHIVAL_GROUP`) for users who want to filter by archival group type

## Context
Reported twice by a user in `#rubrik-powershell-sdk` (Feb 19, Mar 4) — they had a datacenter NFS archive target that was invisible to the cmdlet.

Fixes SPARK-752416

## Test plan
- [ ] Run `Get-RscArchivalLocation` with no params — should return all archival group types including datacenter NFS
- [ ] Run `Get-RscArchivalLocation -GroupType CLOUD_NATIVE_ARCHIVAL_GROUP` — should return only cloud-native (old behavior)
- [ ] Run `Get-RscArchivalLocation -GroupType DATACENTER_ARCHIVAL_GROUP` — should return datacenter targets (NFS, etc.)
- [ ] Run `Get-RscArchivalLocation -Name "somename"` — name filtering still works
- [ ] Run `Get-RscArchivalLocation -Name "somename" -GroupType DATACENTER_ARCHIVAL_GROUP` — both filters combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)