### PR TITLE
Extend on: type selector to all interface contexts, add * wildcard

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscType.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscType.cs
@@ -132,7 +132,10 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                 CommandAst commandAst,
                 IDictionary fakeBoundParameters)
             {
-                var validNames = RscTypeInitializer.GetAllTypeNames()
+                var classNames = RscTypeInitializer.GetAllTypeNames();
+                var ifaceNames = RscTypeInitializer.GetAllTypeNames(
+                    interfaces: true);
+                var validNames = classNames.Concat(ifaceNames)
                     .Where(name => string.IsNullOrEmpty(wordToComplete) ||
                                    name.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase));
 
@@ -213,6 +216,14 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                 bool atInterfaceList = false;
                 Type interfaceElementType = null;
 
+                // If the root type is an interface, offer on: selectors
+                // at the first position.
+                if (rootType.IsInterface && segments.Length == 1)
+                {
+                    atInterfaceList = true;
+                    interfaceElementType = rootType;
+                }
+
                 // Walk completed segments (all except the last, which is partial).
                 for (int i = 0; i < segments.Length - 1; i++)
                 {
@@ -277,15 +288,22 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                         continue;
                     }
 
-                    // Single interface
+                    // Single interface — offer on: selectors
                     if (propType.IsInterface)
                     {
-                        var impls = ReflectionUtils.GetTypesImplementingInterface(propType.Name);
-                        if (impls.Count > 0)
-                            currentType = RscTypeInitializer.GetTypeByName(impls[0]);
-                        atInterfaceList = false;
-                        interfaceElementType = null;
+                        atInterfaceList = true;
+                        interfaceElementType = propType;
                         continue;
+                    }
+
+                    // Scalar/leaf — no sub-properties to complete.
+                    if (propType == typeof(string) ||
+                        propType.IsPrimitive ||
+                        propType.IsEnum ||
+                        propType == typeof(DateTime) ||
+                        (Nullable.GetUnderlyingType(propType) != null))
+                    {
+                        return Enumerable.Empty<CompletionResult>();
                     }
 
                     // Class — advance
@@ -361,6 +379,17 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
 
                 // Regular property completion on currentType.
                 var propResults = new List<CompletionResult>();
+
+                // Offer "*" wildcard (all scalar properties)
+                if (string.IsNullOrEmpty(partial) ||
+                    "*".StartsWith(partial, StringComparison.OrdinalIgnoreCase))
+                {
+                    propResults.Add(new CompletionResult(
+                        q(prefix + "*"), "*",
+                        CompletionResultType.ParameterValue,
+                        "All scalar properties"));
+                }
+
                 foreach (PropertyInfo p in currentType.GetProperties(
                     BindingFlags.Instance | BindingFlags.Public))
                 {
@@ -500,7 +529,17 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
                         }
                         else
                         {
-                            WriteObject(Activator.CreateInstance(returnType));
+                            if (returnType.IsInterface)
+                            {
+                                WriteObject(
+                                    InterfaceHelper.CreateInstanceOfFirstType(
+                                        returnType));
+                            }
+                            else
+                            {
+                                WriteObject(
+                                    Activator.CreateInstance(returnType));
+                            }
                         }
                         break;
                 }

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscType.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Cmdlets/Get-RscType.cs
@@ -143,6 +143,9 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
         /// <summary>
         /// Property names (or dotted paths) to initialize with sentinel values.
         /// Supports dotted paths like "nodes.id" to walk into nested objects.
+        /// For List&lt;Interface&gt; fields, use "on:TypeName" to select a
+        /// specific implementing type (e.g. "nodes.on:PhysicalHost.id")
+        /// or "on:*" for all types.
         /// See RscTypeInitializer.InitializeTypeWithSelectedProperties for
         /// the sentinel values used for each property type.
         /// Mutually exclusive with -InitialValues.
@@ -153,7 +156,226 @@ namespace RubrikSecurityCloud.PowerShell.Cmdlets
             ValueFromPipeline = false,
             ParameterSetName = "GetTypeByName")]
         [ValidateNotNullOrEmpty]
+        [ArgumentCompleter(typeof(InitialPropertiesCompleter))]
         public string[] InitialProperties { get; set; }
+
+        /// <summary>
+        /// Tab-completion for the -InitialProperties parameter.
+        /// Walks the dotted path to determine the current type context,
+        /// then offers property names or on:TypeName selectors for
+        /// List&lt;Interface&gt; fields.
+        /// </summary>
+        public class InitialPropertiesCompleter : IArgumentCompleter
+        {
+            /// <summary>Provide completions for the InitialProperties parameter.</summary>
+            public IEnumerable<CompletionResult> CompleteArgument(
+                string commandName,
+                string parameterName,
+                string wordToComplete,
+                CommandAst commandAst,
+                IDictionary fakeBoundParameters)
+            {
+                // Need -Name to know which type we're completing for.
+                if (!fakeBoundParameters.Contains("Name"))
+                    return Enumerable.Empty<CompletionResult>();
+
+                string typeName = fakeBoundParameters["Name"]?.ToString();
+                if (string.IsNullOrEmpty(typeName))
+                    return Enumerable.Empty<CompletionResult>();
+
+                Type rootType = RscTypeInitializer.GetTypeByName(typeName);
+                if (rootType == null)
+                    return Enumerable.Empty<CompletionResult>();
+
+                // PowerShell passes the opening quote as part of wordToComplete
+                // when the user is typing inside quotes (e.g. "C or 'C).
+                // Strip it so matching works, and remember the quote char
+                // so we can wrap completion results.
+                string raw = wordToComplete ?? "";
+                char quoteChar = '\0';
+                if (raw.Length > 0 && (raw[0] == '"' || raw[0] == '\''))
+                {
+                    quoteChar = raw[0];
+                    raw = raw.Substring(1);
+                }
+                // Also strip a trailing quote if present.
+                if (raw.Length > 0 && quoteChar != '\0' &&
+                    raw[raw.Length - 1] == quoteChar)
+                {
+                    raw = raw.Substring(0, raw.Length - 1);
+                }
+
+                // Split the word being completed into segments.
+                // e.g. "nodes.on:PhysicalHost.i" → ["nodes", "on:PhysicalHost", "i"]
+                string[] segments = raw.Split('.');
+                string prefix = ""; // rebuilt prefix of completed segments
+                Type currentType = rootType;
+                bool atInterfaceList = false;
+                Type interfaceElementType = null;
+
+                // Walk completed segments (all except the last, which is partial).
+                for (int i = 0; i < segments.Length - 1; i++)
+                {
+                    string seg = segments[i];
+                    if (string.IsNullOrEmpty(seg))
+                        return Enumerable.Empty<CompletionResult>();
+
+                    prefix += (i > 0 ? "." : "") + seg;
+
+                    // Handle on: selector — switch into the selected type.
+                    if (seg.StartsWith("on:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string selector = seg.Substring(3);
+                        if (selector == "*")
+                        {
+                            // on:* — can't narrow type, but we know we're
+                            // past the interface list. Pick the first
+                            // implementing type for property completion.
+                            if (interfaceElementType != null)
+                            {
+                                var impls = ReflectionUtils.GetTypesImplementingInterface(
+                                    interfaceElementType.Name);
+                                if (impls.Count > 0)
+                                    currentType = RscTypeInitializer.GetTypeByName(impls[0]);
+                            }
+                        }
+                        else
+                        {
+                            Type selectedType = RscTypeInitializer.GetTypeByName(selector);
+                            if (selectedType != null)
+                                currentType = selectedType;
+                            else
+                                return Enumerable.Empty<CompletionResult>();
+                        }
+                        atInterfaceList = false;
+                        interfaceElementType = null;
+                        continue;
+                    }
+
+                    // Regular property segment — resolve it.
+                    PropertyInfo prop = currentType.GetProperty(seg,
+                        BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public);
+                    if (prop == null)
+                        return Enumerable.Empty<CompletionResult>();
+
+                    Type propType = prop.PropertyType;
+
+                    // Check for List<T>
+                    if (propType.IsGenericType &&
+                        propType.GetGenericTypeDefinition() == typeof(List<>))
+                    {
+                        Type elemType = propType.GetGenericArguments()[0];
+                        if (elemType.IsInterface)
+                        {
+                            atInterfaceList = true;
+                            interfaceElementType = elemType;
+                            continue;
+                        }
+                        currentType = elemType;
+                        atInterfaceList = false;
+                        interfaceElementType = null;
+                        continue;
+                    }
+
+                    // Single interface
+                    if (propType.IsInterface)
+                    {
+                        var impls = ReflectionUtils.GetTypesImplementingInterface(propType.Name);
+                        if (impls.Count > 0)
+                            currentType = RscTypeInitializer.GetTypeByName(impls[0]);
+                        atInterfaceList = false;
+                        interfaceElementType = null;
+                        continue;
+                    }
+
+                    // Class — advance
+                    currentType = propType;
+                    atInterfaceList = false;
+                    interfaceElementType = null;
+                }
+
+                // The last segment is the partial text being completed.
+                string partial = segments[segments.Length - 1];
+                if (segments.Length > 1)
+                    prefix += ".";
+
+                // Helper: wrap completionText in quotes when the user
+                // started typing inside quotes.
+                Func<string, string> q = (string val) =>
+                    quoteChar == '\0' ? val : quoteChar + val + quoteChar;
+
+                // If we're right after a List<Interface> field, offer on: selectors.
+                if (atInterfaceList && interfaceElementType != null)
+                {
+                    var results = new List<CompletionResult>();
+                    var impls = ReflectionUtils.GetTypesImplementingInterface(
+                        interfaceElementType.Name);
+
+                    // on:* completion
+                    string onStar = "on:*";
+                    if (onStar.StartsWith(partial, StringComparison.OrdinalIgnoreCase))
+                    {
+                        results.Add(new CompletionResult(
+                            q(prefix + onStar), onStar, CompletionResultType.ParameterValue,
+                            "All implementing types"));
+                    }
+
+                    // on:TypeName completions
+                    foreach (string impl in impls)
+                    {
+                        string onType = "on:" + impl;
+                        if (onType.StartsWith(partial, StringComparison.OrdinalIgnoreCase))
+                        {
+                            results.Add(new CompletionResult(
+                                q(prefix + onType), onType, CompletionResultType.ParameterValue,
+                                impl));
+                        }
+                    }
+
+                    // Also offer bare field names expanded to on:*.field
+                    // for backward compatibility discovery.
+                    if (!partial.StartsWith("on:", StringComparison.OrdinalIgnoreCase) &&
+                        impls.Count > 0)
+                    {
+                        Type firstImpl = RscTypeInitializer.GetTypeByName(impls[0]);
+                        if (firstImpl != null)
+                        {
+                            foreach (PropertyInfo p in firstImpl.GetProperties(
+                                BindingFlags.Instance | BindingFlags.Public))
+                            {
+                                if (string.IsNullOrEmpty(partial) ||
+                                    p.Name.StartsWith(partial, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    string expanded = "on:*." + p.Name;
+                                    results.Add(new CompletionResult(
+                                        q(prefix + expanded), expanded,
+                                        CompletionResultType.ParameterValue,
+                                        $"{p.Name} (all types)"));
+                                }
+                            }
+                        }
+                    }
+
+                    return results;
+                }
+
+                // Regular property completion on currentType.
+                var propResults = new List<CompletionResult>();
+                foreach (PropertyInfo p in currentType.GetProperties(
+                    BindingFlags.Instance | BindingFlags.Public))
+                {
+                    if (string.IsNullOrEmpty(partial) ||
+                        p.Name.StartsWith(partial, StringComparison.OrdinalIgnoreCase))
+                    {
+                        propResults.Add(new CompletionResult(
+                            q(prefix + p.Name), p.Name,
+                            CompletionResultType.ParameterValue,
+                            $"{p.PropertyType.Name}"));
+                    }
+                }
+                return propResults;
+            }
+        }
 
         /// <summary>
         /// A hashtable mapping property names to specific values.

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscTypeInitializer.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscTypeInitializer.cs
@@ -313,6 +313,13 @@ namespace RubrikSecurityCloud.PowerShell.Private
                     $"No type found matching: '{objectClassName}'");
             }
 
+            // Interface root: delegate to InitializeInterfaceRoot
+            if (returnType.IsInterface)
+            {
+                return InitializeInterfaceRoot(
+                    returnType, requestedProperties);
+            }
+
             object returnInstance = Activator.CreateInstance(returnType);
 
             // Outer loop: each requestedProperty is an independent path.
@@ -326,6 +333,19 @@ namespace RubrikSecurityCloud.PowerShell.Private
                 // At each step, currentObject advances to the nested object.
                 for (int i = 0; i < segments.Length; i++)
                 {
+                    // "*" wildcard: set all scalar properties on
+                    // the current object. Must be the last segment.
+                    if (segments[i] == "*")
+                    {
+                        foreach (PropertyInfo p in currentObject.GetType()
+                            .GetProperties(BindingFlags.Instance |
+                                           BindingFlags.Public))
+                        {
+                            SetScalarSentinel(currentObject, p);
+                        }
+                        break;
+                    }
+
                     PropertyInfo prop = currentObject.GetType()
                         .GetProperty(segments[i],
                             BindingFlags.IgnoreCase |
@@ -441,8 +461,29 @@ namespace RubrikSecurityCloud.PowerShell.Private
                     // then advance.
                     if (prop.PropertyType.IsClass || prop.PropertyType.IsInterface)
                     {
-                        currentObject = GetOrCreatePropertyValue(
-                            currentObject, prop);
+                        if (prop.PropertyType.IsInterface &&
+                            i + 1 < segments.Length &&
+                            segments[i + 1].StartsWith("on:",
+                                StringComparison.OrdinalIgnoreCase))
+                        {
+                            string selector = segments[i + 1].Substring(3);
+                            i++; // consume the on: segment
+                            if (selector == "*")
+                            {
+                                currentObject = GetOrCreatePropertyValue(
+                                    currentObject, prop);
+                            }
+                            else
+                            {
+                                currentObject = GetOrCreatePropertyValue(
+                                    currentObject, prop, selector);
+                            }
+                        }
+                        else
+                        {
+                            currentObject = GetOrCreatePropertyValue(
+                                currentObject, prop);
+                        }
                         continue;
                     }
 
@@ -453,6 +494,101 @@ namespace RubrikSecurityCloud.PowerShell.Private
                 }
             }
             return returnInstance;
+        }
+
+        /// <summary>
+        /// Handle an interface as the root type. Groups requestedProperties
+        /// by on: type selector, initializes each implementing type
+        /// independently, then chains them into a composite via
+        /// MakeCompositeFromList.
+        ///
+        /// Supported property forms:
+        ///   on:TypeName.field  → only that implementing type
+        ///   on:*.field         → all implementing types
+        ///   field (no on:)     → all implementing types (backward compat)
+        /// </summary>
+        private static object InitializeInterfaceRoot(
+            System.Type interfaceType,
+            string[] requestedProperties)
+        {
+            var implNames = ReflectionUtils.GetTypesImplementingInterface(
+                interfaceType.Name);
+
+            // Group properties: key = type name or "*" for wildcard/bare.
+            var groups = new Dictionary<string, List<string>>(
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (string rp in requestedProperties)
+            {
+                string[] parts = rp.Split(new[] { '.' }, 2);
+                string first = parts[0];
+                string rest = parts.Length > 1 ? parts[1] : null;
+
+                if (first.StartsWith("on:", StringComparison.OrdinalIgnoreCase))
+                {
+                    string selector = first.Substring(3);
+                    string key = selector == "*" ? "*" : selector;
+                    if (!groups.ContainsKey(key))
+                        groups[key] = new List<string>();
+                    if (rest != null)
+                        groups[key].Add(rest);
+                }
+                else
+                {
+                    // Bare property — treat as wildcard
+                    if (!groups.ContainsKey("*"))
+                        groups["*"] = new List<string>();
+                    groups["*"].Add(rp);
+                }
+            }
+
+            // Validate specific type names
+            foreach (string key in groups.Keys)
+            {
+                if (key == "*") continue;
+                if (!implNames.Contains(key, StringComparer.OrdinalIgnoreCase))
+                {
+                    throw new Exception(
+                        $"Type '{key}' does not implement " +
+                        $"interface '{interfaceType.Name}'. " +
+                        $"Use on:* to see all implementing types.");
+                }
+            }
+
+            List<string> wildcardProps = groups.ContainsKey("*")
+                ? groups["*"] : null;
+
+            // Always create ALL implementing types so AsFieldSpec()
+            // produces proper inline fragments (... on TypeName).
+            // Only selected types get their properties initialized;
+            // unselected types remain empty (all nulls → skipped by
+            // AsFieldSpec).
+            var instances = new List<object>();
+            foreach (string typeName in implNames)
+            {
+                var props = new List<string>();
+
+                // Add wildcard properties
+                if (wildcardProps != null)
+                    props.AddRange(wildcardProps);
+
+                // Add type-specific properties
+                if (groups.ContainsKey(typeName))
+                    props.AddRange(groups[typeName]);
+
+                if (props.Count > 0)
+                {
+                    instances.Add(InitializeTypeWithSelectedProperties(
+                        typeName, props.ToArray()));
+                }
+                else
+                {
+                    instances.Add(Activator.CreateInstance(
+                        GetTypeByName(typeName)));
+                }
+            }
+
+            return InterfaceHelper.MakeCompositeFromList(instances);
         }
 
         /// <summary>
@@ -542,6 +678,29 @@ namespace RubrikSecurityCloud.PowerShell.Private
                 child = Activator.CreateInstance(prop.PropertyType);
             }
 
+            prop.SetValue(parent, child);
+            return child;
+        }
+
+        /// <summary>
+        /// Overload: create a specific implementing type for an interface
+        /// property. Used when an on:TypeName selector is provided.
+        /// </summary>
+        private static object GetOrCreatePropertyValue(
+            object parent, PropertyInfo prop, string typeName)
+        {
+            object child = prop.GetValue(parent);
+            if (child != null) return child;
+
+            System.Type targetType = GetTypeByName(typeName);
+            if (targetType == null ||
+                !prop.PropertyType.IsAssignableFrom(targetType))
+            {
+                throw new Exception(
+                    $"Type '{typeName}' does not implement " +
+                    $"interface '{prop.PropertyType.Name}'.");
+            }
+            child = Activator.CreateInstance(targetType);
             prop.SetValue(parent, child);
             return child;
         }

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscTypeInitializer.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/Private/RscTypeInitializer.cs
@@ -358,8 +358,18 @@ namespace RubrikSecurityCloud.PowerShell.Private
                         {
                             if (elementType.IsInterface)
                             {
+                                // Check for on: type selector in next segment
+                                string typeFilter = null;
+                                if (i + 1 < segments.Length &&
+                                    segments[i + 1].StartsWith("on:", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    string selector = segments[i + 1].Substring(3);
+                                    typeFilter = selector == "*" ? null : selector;
+                                    i++; // consume the on: segment
+                                }
                                 currentObject = InitializeInterfaceList(
                                     currentObject, prop, elementType,
+                                    typeFilter,
                                     requestedProperties, segments, i);
                             }
                             else
@@ -374,8 +384,55 @@ namespace RubrikSecurityCloud.PowerShell.Private
                         }
                         else
                         {
-                            // List already exists — advance into first element.
-                            currentObject = ((IList)prop.GetValue(currentObject))[0];
+                            // List already exists.
+                            IList existingList = (IList)prop.GetValue(currentObject);
+
+                            // Check for on: type selector
+                            if (i + 1 < segments.Length &&
+                                segments[i + 1].StartsWith("on:", StringComparison.OrdinalIgnoreCase))
+                            {
+                                string selector = segments[i + 1].Substring(3);
+                                i++; // consume the on: segment
+
+                                if (selector != "*")
+                                {
+                                    // Find existing element of this type, or create and add one.
+                                    object match = null;
+                                    foreach (var item in existingList)
+                                    {
+                                        if (string.Equals(item.GetType().Name, selector,
+                                            StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            match = item;
+                                            break;
+                                        }
+                                    }
+                                    if (match == null)
+                                    {
+                                        System.Type matchType = GetTypeByName(selector);
+                                        if (matchType == null || !elementType.IsAssignableFrom(matchType))
+                                        {
+                                            throw new Exception(
+                                                $"Type '{selector}' does not implement " +
+                                                $"interface '{elementType.Name}'. " +
+                                                $"Use on:* to see all implementing types.");
+                                        }
+                                        match = Activator.CreateInstance(matchType);
+                                        existingList.Add(match);
+                                    }
+                                    currentObject = match;
+                                }
+                                else
+                                {
+                                    // on:* with existing list — advance into first element.
+                                    currentObject = existingList[0];
+                                }
+                            }
+                            else
+                            {
+                                // No on: selector — advance into first element.
+                                currentObject = existingList[0];
+                            }
                         }
                         continue;
                     }
@@ -490,19 +547,16 @@ namespace RubrikSecurityCloud.PowerShell.Private
         }
 
         /// <summary>
-        /// Handle a List&lt;Interface&gt; property: create one instance of
-        /// EVERY implementing type so the field spec includes all possible
-        /// inline fragments (... on TypeA, ... on TypeB, etc.).
+        /// Handle a List&lt;Interface&gt; property: create instances of
+        /// implementing types so the field spec includes inline fragments.
+        ///
+        /// When typeFilter is null, creates ALL implementing types
+        /// (... on TypeA, ... on TypeB, etc.).
+        /// When typeFilter is a type name, creates only that type.
         ///
         /// Strips the parent prefix from property paths before recursing.
         /// For example, ["nodes.id"] at depth i=0 ("nodes") becomes ["id"]
         /// for each implementing type.
-        ///
-        /// If you only want a SINGLE implementing type (e.g. just
-        /// PhysicalHost), you cannot achieve that with -InitialProperties.
-        /// You must create the type separately and manually assign it to
-        /// the list. See the unit test "Double interface list" for a
-        /// worked example.
         ///
         /// Returns the first element of the initialized list (for further
         /// walking by the caller).
@@ -511,6 +565,7 @@ namespace RubrikSecurityCloud.PowerShell.Private
             object currentObject,
             PropertyInfo prop,
             System.Type interfaceType,
+            string typeFilter,
             string[] requestedProperties,
             string[] currentSegments,
             int depth)
@@ -523,6 +578,35 @@ namespace RubrikSecurityCloud.PowerShell.Private
 
             IList templateList = (IList)method.Invoke(
                 null, new object[] { interfaceType });
+
+            // Filter to a single implementing type if requested.
+            if (typeFilter != null)
+            {
+                var filtered = new List<object>();
+                foreach (var item in templateList)
+                {
+                    if (string.Equals(item.GetType().Name, typeFilter,
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        filtered.Add(item);
+                    }
+                }
+                if (filtered.Count == 0)
+                {
+                    throw new Exception(
+                        $"Type '{typeFilter}' does not implement " +
+                        $"interface '{interfaceType.Name}'. " +
+                        $"Use on:* to see all implementing types.");
+                }
+                // Rebuild templateList with only the matching type.
+                IList filteredList = (IList)Activator.CreateInstance(
+                    templateList.GetType());
+                foreach (var item in filtered)
+                {
+                    filteredList.Add(item);
+                }
+                templateList = filteredList;
+            }
 
             // Build an empty list of the same generic type.
             IList resultList = (IList)Activator.CreateInstance(

--- a/Tests/e2e/Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1
+++ b/Tests/e2e/Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1
@@ -2,42 +2,20 @@ BeforeAll {
     . "$PSScriptRoot\..\E2eTestInit.ps1"
 }
 Describe -Name 'Query mssqlTopLevelDescendants' -Fixture {
-    # This test exercises a key Get-RscType limitation with List<Interface>
-    # fields and shows the workaround.
+    # This test exercises manual field spec construction for List<Interface>
+    # fields. The same result can be achieved more concisely with the on:
+    # type selector syntax (e.g. "nodes.on:PhysicalHost.id"), but this
+    # manual approach remains valid and is kept here to exercise that path.
     #
     # MssqlTopLevelDescendantTypeConnection.nodes is a List<MssqlTopLevelDescendantType>,
     # where MssqlTopLevelDescendantType is an INTERFACE with 6 implementing types:
     #   MssqlAvailabilityGroup, MssqlDatabase, MssqlHost,
     #   MssqlInstance, PhysicalHost, WindowsCluster
     #
-    # If we used Get-RscType with -InitialProperties "nodes.id", the
-    # List<Interface> code path would create one instance of EVERY
-    # implementing type, producing a field spec with all 6 fragments:
-    #
-    #   nodes {
-    #     ... on MssqlAvailabilityGroup { id }
-    #     ... on MssqlDatabase { id }
-    #     ... on MssqlHost { id }
-    #     ... on MssqlInstance { id }
-    #     ... on PhysicalHost { id }
-    #     ... on WindowsCluster { id }
-    #   }
-    #
-    # But here we only want PhysicalHost (and its child MssqlInstances).
-    # Get-RscType has no way to select a single implementing type from an
-    # interface list. The workaround is to:
+    # Here we only want PhysicalHost (and its child MssqlInstances).
+    # The manual approach:
     #   1. Create the specific implementing type separately (PhysicalHost)
     #   2. Manually assign it to .nodes on an empty Connection object
-    #
-    # This gives us a targeted field spec with only the PhysicalHost fragment:
-    #
-    #   nodes {
-    #     ... on PhysicalHost {
-    #       id
-    #       name
-    #       physicalChildConnection { count nodes { ... } }
-    #     }
-    #   }
     #
     # The same pattern applies one level deeper:
     # PhysicalHost.physicalChildConnection.nodes is also a List<Interface>

--- a/Tests/unit/Get-RscType.Tests.ps1
+++ b/Tests/unit/Get-RscType.Tests.ps1
@@ -187,6 +187,80 @@ Describe 'Get-RscType' {
         }
     }
 
+    Context 'on: type selector for List<Interface>' {
+        It '"nodes.on:*.id" — explicit all-types, same result as "nodes.id"' {
+            $explicit = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @("nodes.on:*.id")
+            $implicit = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @("nodes.id")
+            $explicit.nodes.Count | Should -Be $implicit.nodes.Count
+            foreach ($node in $explicit.nodes) {
+                $node.Id | Should -Be "FETCH"
+            }
+        }
+
+        It '"nodes.on:PhysicalHost.id" — single type, only PhysicalHost fragment' {
+            $result = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @("nodes.on:PhysicalHost.id")
+            $result.nodes.Count | Should -Be 1
+            $result.nodes[0] | Should -BeOfType RubrikSecurityCloud.Types.PhysicalHost
+            $result.nodes[0].Id | Should -Be "FETCH"
+        }
+
+        It '"nodes.on:PhysicalHost.id", "nodes.on:MssqlDatabase.name" — two specific types' {
+            $result = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @("nodes.on:PhysicalHost.id", "nodes.on:MssqlDatabase.name")
+            $result.nodes.Count | Should -Be 2
+            $phHost = $result.nodes | Where-Object { $_ -is [RubrikSecurityCloud.Types.PhysicalHost] }
+            $mssql = $result.nodes | Where-Object { $_ -is [RubrikSecurityCloud.Types.MssqlDatabase] }
+            $phHost | Should -Not -BeNull
+            $phHost.Id | Should -Be "FETCH"
+            $mssql | Should -Not -BeNull
+            $mssql.Name | Should -Be "FETCH"
+        }
+
+        It '"nodes.on:NonExistent.id" — throws with clear error' {
+            { Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @("nodes.on:NonExistent.id") } |
+                Should -Throw "*does not implement*MssqlTopLevelDescendantType*"
+        }
+
+        It 'Backward compat: "nodes.id" still works unchanged' {
+            $result = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @("nodes.id")
+            $typeList = Get-RscType -Interface "MssqlTopLevelDescendantType"
+            $result.nodes.Count | Should -Be $typeList.Count
+        }
+
+        It 'Double interface with on: produces same field spec as manual workaround' {
+            # A: new way — single Get-RscType call with on: selectors
+            $a = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+                -InitialProperties @(
+                    "nodes.on:PhysicalHost.id",
+                    "nodes.on:PhysicalHost.name",
+                    "nodes.on:PhysicalHost.physicalChildConnection.count",
+                    "nodes.on:PhysicalHost.physicalChildConnection.nodes.on:MssqlInstance.id",
+                    "nodes.on:PhysicalHost.physicalChildConnection.nodes.on:MssqlInstance.name"
+                )
+
+            # B: old way — manual 4-step workaround
+            # (mirrors Tests/e2e/Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1)
+            $physicalHostFields =
+                Get-RscType -Name PhysicalHost -InitialProperties @(
+                    "id",
+                    "name",
+                    "physicalChildConnection.count"
+                )
+            $physicalHostFields.PhysicalChildConnection.Nodes =
+                Get-RscType -Name MssqlInstance -InitialProperties ("Id", "Name")
+            $b = Get-RscType -Name MssqlTopLevelDescendantTypeConnection
+            $b.nodes = $physicalHostFields
+
+            # A and B must produce the same field spec
+            $a.AsFieldSpec() | Should -Be $b.AsFieldSpec()
+        }
+    }
+
     Context 'Double interface list: manual field spec construction' {
         # This mirrors the e2e test in Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1
         # and exercises a real-world pattern for working with nested interface lists.

--- a/Tests/unit/Get-RscType.Tests.ps1
+++ b/Tests/unit/Get-RscType.Tests.ps1
@@ -340,4 +340,133 @@ Describe 'Get-RscType' {
             $fragmentCount | Should -Be 6
         }
     }
+
+    Context 'on: type selector for root interface types' {
+        It 'Bare "Get-RscType -Name SlaDomain" returns a non-null object' {
+            $result = Get-RscType -Name SlaDomain
+            $result | Should -Not -BeNull
+        }
+
+        It '"on:ClusterSlaDomain.Id" — ClusterSlaDomain fragment has id' {
+            $result = Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:ClusterSlaDomain.Id")
+            $spec = $result.AsFieldSpec()
+            ($spec -match '\.\.\. on ClusterSlaDomain') | Should -Be $true
+            ($spec -match 'id') | Should -Be $true
+        }
+
+        It '"on:GlobalSlaReply.Id" — GlobalSlaReply fragment has id' {
+            $result = Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:GlobalSlaReply.Id")
+            $spec = $result.AsFieldSpec()
+            ($spec -match '\.\.\. on GlobalSlaReply') | Should -Be $true
+            ($spec -match 'id') | Should -Be $true
+        }
+
+        It '"on:*.Id" — composite of all implementing types, each with Id=FETCH' {
+            $result = Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:*.Id")
+            $result | Should -Not -BeNull
+            # Result should be a composite (BaseType with linked list)
+            $result.Id | Should -Be "FETCH"
+            # Verify it's a composite by checking AsFieldSpec has multiple fragments
+            $spec = $result.AsFieldSpec()
+            ($spec -match '\.\.\. on ClusterSlaDomain') | Should -Be $true
+            ($spec -match '\.\.\. on GlobalSlaReply') | Should -Be $true
+        }
+
+        It '"Id" (bare, no on:) — same as on:*.Id' {
+            $result = Get-RscType -Name SlaDomain `
+                -InitialProperties @("Id")
+            $result | Should -Not -BeNull
+            $spec = $result.AsFieldSpec()
+            ($spec -match '\.\.\. on ClusterSlaDomain') | Should -Be $true
+            ($spec -match '\.\.\. on GlobalSlaReply') | Should -Be $true
+        }
+
+        It '"on:NonExistent.Id" — throws' {
+            { Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:NonExistent.Id") } |
+                Should -Throw "*does not implement*SlaDomain*"
+        }
+
+        It 'on: result AsFieldSpec matches equivalent on:*.Id' {
+            # Both should produce the same field spec
+            $a = Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:ClusterSlaDomain.Id", "on:GlobalSlaReply.Id")
+            $b = Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:*.Id")
+            $a.AsFieldSpec() | Should -Be $b.AsFieldSpec()
+        }
+    }
+
+    Context 'on: type selector for single interface properties' {
+        It '"EffectiveSlaDomain.on:GlobalSlaReply.Id" — GlobalSlaReply with Id=FETCH' {
+            $result = Get-RscType -Name MssqlDatabase `
+                -InitialProperties @("EffectiveSlaDomain.on:GlobalSlaReply.Id")
+            $result.EffectiveSlaDomain | Should -Not -BeNull
+            $result.EffectiveSlaDomain | Should -BeOfType RubrikSecurityCloud.Types.GlobalSlaReply
+            $result.EffectiveSlaDomain.Id | Should -Be "FETCH"
+        }
+
+        It '"EffectiveSlaDomain.on:ClusterSlaDomain.Id" — ClusterSlaDomain with Id=FETCH' {
+            $result = Get-RscType -Name MssqlDatabase `
+                -InitialProperties @("EffectiveSlaDomain.on:ClusterSlaDomain.Id")
+            $result.EffectiveSlaDomain | Should -Not -BeNull
+            $result.EffectiveSlaDomain | Should -BeOfType RubrikSecurityCloud.Types.ClusterSlaDomain
+            $result.EffectiveSlaDomain.Id | Should -Be "FETCH"
+        }
+
+        It '"EffectiveSlaDomain.Id" (bare) — first implementing type with Id=FETCH (backward compat)' {
+            $result = Get-RscType -Name MssqlDatabase `
+                -InitialProperties @("EffectiveSlaDomain.Id")
+            $result.EffectiveSlaDomain | Should -Not -BeNull
+            $result.EffectiveSlaDomain | Should -BeOfType RubrikSecurityCloud.Types.ClusterSlaDomain
+            $result.EffectiveSlaDomain.Id | Should -Be "FETCH"
+        }
+
+        It '"EffectiveSlaDomain.on:NonExistent.Id" — throws' {
+            { Get-RscType -Name MssqlDatabase `
+                -InitialProperties @("EffectiveSlaDomain.on:NonExistent.Id") } |
+                Should -Throw "*does not implement*"
+        }
+    }
+
+    Context '* wildcard for all scalar properties' {
+        It '"CloudInfo.*" sets all scalar fields on CloudInfo' {
+            $result = Get-RscType -Name Cluster -InitialProperties @("CloudInfo.*")
+            $result.CloudInfo | Should -Not -BeNull
+            # CcWithCloudInfo has string properties like Name, Uuid, Region
+            $result.CloudInfo.Name | Should -Be "FETCH"
+            $result.CloudInfo.Uuid | Should -Be "FETCH"
+            $result.CloudInfo.Region | Should -Be "FETCH"
+            # Root fields should not be set
+            $result.Name | Should -BeNullOrEmpty
+        }
+
+        It '"*" at root sets all scalar fields' {
+            $result = Get-RscType -Name AccountSetting -InitialProperties @("*")
+            $result.IsEulaAccepted | Should -Be $true
+        }
+
+        It 'Works with on: — "on:GlobalSlaReply.SnapshotSchedule.Minute.BasicSchedule.*"' {
+            $result = Get-RscType -Name SlaDomain `
+                -InitialProperties @("on:GlobalSlaReply.SnapshotSchedule.Minute.BasicSchedule.*")
+            $spec = $result.AsFieldSpec()
+            ($spec -match 'retention') | Should -Be $true
+            ($spec -match 'frequency') | Should -Be $true
+            ($spec -match 'retentionUnit') | Should -Be $true
+        }
+
+        It '"*" is equivalent to listing all scalar properties individually' {
+            $wildcard = Get-RscType -Name Cluster -InitialProperties @("CloudInfo.*")
+            $explicit = Get-RscType -Name Cluster -InitialProperties @(
+                "CloudInfo.Name", "CloudInfo.Uuid", "CloudInfo.Region"
+            )
+            # Wildcard sets at least the same fields as explicit
+            $explicit.CloudInfo.Name | Should -Be $wildcard.CloudInfo.Name
+            $explicit.CloudInfo.Uuid | Should -Be $wildcard.CloudInfo.Uuid
+            $explicit.CloudInfo.Region | Should -Be $wildcard.CloudInfo.Region
+        }
+    }
 }

--- a/Toolkit/Public/Get-RscHelp.ps1
+++ b/Toolkit/Public/Get-RscHelp.ps1
@@ -283,13 +283,37 @@ function Get-RscHelp {
                 Write-Output "# No match found for '$Match'."
             }
             else {
-                if ($rootFieldData.Count -gt 0) {
-                    $rootFieldData | Sort-Object Kind, GqlField | Format-Table -Property Kind, GqlField, ReturnType -AutoSize
+                # Build a single unified table with numbered matches
+                $rows = @()
+                $n = 0
+                foreach ($rf in ($rootFieldData | Sort-Object Kind, GqlField)) {
+                    $n++
+                    $rows += New-Object PSObject -Property ([ordered]@{
+                        '#'   = $n
+                        Kind  = $rf.Kind
+                        Name  = $rf.GqlField
+                        Info  = "returns $($rf.ReturnType)"
+                    })
                 }
-                if ($otherData.Count -gt 0) {
-                    $otherData | Sort-Object Type, Name | Format-Table -Property Type, Name -AutoSize
+                foreach ($item in ($otherData | Sort-Object Type, Name)) {
+                    $n++
+                    $info = ""
+                    if ($item.Type -eq 'Interface') {
+                        $impls = try { [RubrikSecurityCloud.Types.SchemaMeta]::InterfaceImpls($item.Name) } catch { @() }
+                        if ($impls.Count -gt 0) {
+                            $info = "implemented by: $(($impls | Sort-Object) -join ', ')"
+                        }
+                    }
+                    $rows += New-Object PSObject -Property ([ordered]@{
+                        '#'   = $n
+                        Kind  = $item.Type
+                        Name  = $item.Name
+                        Info  = $info
+                    })
                 }
-                Write-Output "# ${total} matches found for '$Match'."
+                Write-Output ""
+                Write-Output "# $total matches for '$Match':"
+                $rows | Format-Table -Property '#', Kind, Name, Info -AutoSize
             }
         }
 

--- a/docs/HOWTO_create_a_query.md
+++ b/docs/HOWTO_create_a_query.md
@@ -113,14 +113,17 @@ New-RscQuery -Gql clusterConnection -ValidPatchSet |
 ### Use a field object for full manual control
 
 ```powershell
-$fieldObj = Get-RscType -Name ClusterConnection -InitialProperties @(
-    "Nodes.Id", "Nodes.Name", "Nodes.Version"
-)
+$fieldObj = Get-RscType -Name ClusterConnection -InitialProperties Nodes.Id,Nodes.Name,Nodes.Version
 $q = New-RscQuery -Gql clusterConnection -Field $fieldObj -FieldProfile EMPTY
 ```
 
-See [AutoField](./autofield.md) for full details on profiles, patches,
-and field objects.
+This is the **field spec** approach: you specify exactly which fields
+to retrieve, and the query never changes unless you change it. Good for
+production scripts and stable integrations.
+
+See [Field Spec](./fieldspec.md) for the full guide (including `on:`
+type selectors for interface fields), and [AutoField](./autofield.md)
+for the automatic approach.
 
 ## 4 — Run the Query
 
@@ -169,6 +172,7 @@ $q.GqlRequest().Query    # see the full query text
 ## Related Documentation
 
 - [AutoField](./autofield.md) — how field profiles and patches work
+- [Field Spec](./fieldspec.md) — explicit field selection with Get-RscType
 - [Retrieving Interface Fields](./retrieving_interface_fields.md) —
   working with GraphQL interfaces and composite objects
 - [Developer Manual](./developer_manual.md) — getting started,

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ Recommended reading order for new users:
 4. [How To Run Mutations](HOWTO_mutations.md) — create, update, delete resources
 5. [How To Paginate](HOWTO_pagination.md) — walk through large result sets
 6. [AutoField](autofield.md) — field profiles and customization
-7. [FAQ](faq.md) — common errors and troubleshooting
+7. [Field Spec](fieldspec.md) — explicit field selection with Get-RscType
+8. [FAQ](faq.md) — common errors and troubleshooting
 
 ## Guides
 
@@ -23,6 +24,7 @@ Recommended reading order for new users:
 | [How To Run Mutations](HOWTO_mutations.md)                     | Creating, updating, and deleting resources                     |
 | [How To Paginate](HOWTO_pagination.md)                         | Cursor-based pagination for large result sets                  |
 | [AutoField](autofield.md)                                      | Automatic field selection: profiles, patches, internals        |
+| [Field Spec](fieldspec.md)                                     | Explicit field selection with Get-RscType -InitialProperties   |
 | [Retrieving Interface Fields](retrieving_interface_fields.md)  | Working with GraphQL interfaces and composite objects          |
 | [GraphQL Model](graphql_model.md)                              | Schema introspection utilities                                 |
 | [SDK Architecture](sdk_architecture.md)                        | Internal architecture overview                                 |

--- a/docs/autofield.md
+++ b/docs/autofield.md
@@ -135,13 +135,14 @@ New-RscQuery -Gql clusterConnection -ValidPatchSet |
 ### Using a Field Object (`-Field`)
 
 For full manual control, pass a typed object whose non-null properties
-define the selected fields:
+define the selected fields. This is the **field spec** approach — an
+alternative to AutoField where you specify exactly which fields to
+retrieve. See [Field Spec](./fieldspec.md) for the full guide, including
+the `on:` type selector syntax for interface fields.
 
 ```powershell
-$fieldObj = Get-RscType -Name ClusterConnection -InitialProperties @(
-    "Nodes.Id", "Nodes.Name", "Nodes.Status"
-)
-$q = New-RscQuery -Gql clusterConnection -Field $fieldObj
+$fieldObj = Get-RscType -Name ClusterConnection -InitialProperties Nodes.Id,Nodes.Name,Nodes.Status
+$q = New-RscQuery -Gql clusterConnection -Field $fieldObj -FieldProfile EMPTY
 ```
 
 You can combine `-Field` with `-AddField` / `-RemoveField` — the field

--- a/docs/design_initialproperties_type_selector.md
+++ b/docs/design_initialproperties_type_selector.md
@@ -1,6 +1,6 @@
 # Design: Type Selector Syntax for -InitialProperties
 
-Status: Proposed (not implemented)
+Status: Implemented
 
 ## Problem
 
@@ -106,12 +106,36 @@ type selector because every field ends up inside an inline fragment.
 
 ## Implementation Notes
 
-Changes needed in `RscTypeInitializer.InitializeInterfaceList`:
-- Parse `on:*` and `on:<TypeName>` segments
-- Filter the implementing types list based on selector
-- Strip the `on:` segment before recursing
+### Files Changed
 
-Changes needed in the tab completer (`RscTypeNameCompleter`):
-- Detect when the current path segment follows a `List<Interface>` field
-- Return `on:*` and `on:<TypeName>` completions instead of bare field names
-- When user types a bare field prefix, expand to `on:*.<field>`
+- `RscTypeInitializer.cs` — `InitializeTypeWithSelectedProperties` parses `on:`
+  segments; `InitializeInterfaceList` accepts a `typeFilter` parameter to filter
+  implementing types.
+- `Get-RscType.cs` — new `InitialPropertiesCompleter` class attached to
+  `-InitialProperties`, offers `on:*` and `on:TypeName` completions after
+  `List<Interface>` fields.
+- `Get-RscType.Tests.ps1` — tests for `on:*`, `on:TypeName`, multi-type,
+  error cases, backward compat, and double interface via `on:`.
+
+### Examples
+
+```powershell
+# Only PhysicalHost — one fragment instead of 6
+Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties nodes.on:PhysicalHost.id
+
+# Two specific types
+Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+    -InitialProperties nodes.on:PhysicalHost.id,nodes.on:MssqlDatabase.name
+
+# Double interface — replaces the manual 4-step workaround
+Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties @(
+    "nodes.on:PhysicalHost.id"
+    "nodes.on:PhysicalHost.physicalChildConnection.nodes.on:MssqlInstance.id"
+)
+
+# Explicit all-types (same as bare field)
+Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties nodes.on:*.id
+
+# Backward compatible — still works
+Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties nodes.id
+```

--- a/docs/fieldspec.md
+++ b/docs/fieldspec.md
@@ -1,0 +1,251 @@
+# Field Spec: Explicit Field Selection with Get-RscType
+
+## Two Approaches to Field Selection
+
+The SDK provides two approaches to control which fields your GraphQL
+queries retrieve. They serve different needs:
+
+| Approach    | How it works                            | Best for                            |
+|-------------|-----------------------------------------|-------------------------------------|
+| [AutoField](./autofield.md) | SDK picks fields automatically via profiles | Exploration, scripts that want "enough data" without specifying every field |
+| **Field Spec** | You specify exactly which fields to retrieve | Production scripts, stable integrations, precise control |
+
+### AutoField: Let the SDK Decide
+
+AutoField selects fields automatically based on name-pattern matching
+and profile depth. It's great for getting started quickly:
+
+```powershell
+$q = New-RscQuery -Gql clusterConnection              # DEFAULT profile
+$q = New-RscQuery -Gql clusterConnection -FieldProfile DETAIL  # more fields
+$q = New-RscQuery -Gql clusterConnection -AddField Nodes.GeoLocation.Address
+```
+
+AutoField results can change across SDK versions as profiles are tuned
+or new fields are added to the schema. This is a feature, not a bug: you
+automatically get useful new fields without changing your scripts.
+
+But if your script processes specific fields and you don't want surprises,
+use a field spec.
+
+### Field Spec: You Decide
+
+A field spec is a typed .NET object where non-null properties mark the
+fields to retrieve. The SDK convention: `$null` = "don't request",
+non-null = "request".
+
+```powershell
+$fields = Get-RscType -Name ClusterConnection -InitialProperties Nodes.Id,Nodes.Name,Nodes.Status
+$q = New-RscQuery -Gql clusterConnection -Field $fields -FieldProfile EMPTY
+```
+
+This query will always return exactly `id`, `name`, and `status` for
+each cluster node — nothing more, nothing less, regardless of SDK
+version or schema changes.
+
+`-FieldProfile EMPTY` is important here: it turns off AutoField so only
+your explicitly marked fields are included. Without it, AutoField's
+default selections would be merged in.
+
+## Building Field Specs with Get-RscType
+
+`Get-RscType -InitialProperties` creates a typed object and sets
+sentinel values on the specified properties. The sentinel values (strings
+get `"FETCH"`, bools get `$true`, etc.) just mark the field as non-null
+— their actual value doesn't matter for the query.
+
+### Basic Usage
+
+```powershell
+# Simple flat fields
+$fields = Get-RscType -Name Cluster -InitialProperties Id,Name,Status
+
+# Dotted paths walk into nested objects
+$fields = Get-RscType -Name ClusterConnection -InitialProperties Nodes.Id,Nodes.Name,Nodes.GeoLocation.Address
+```
+
+### Tab Completion
+
+`-InitialProperties` has tab completion that walks the type hierarchy:
+
+```
+Get-RscType -Name ClusterConnection -InitialProperties N<tab>
+# completes to: Nodes
+
+Get-RscType -Name ClusterConnection -InitialProperties Nodes.N<tab>
+# completes to: Nodes.Name, Nodes.NoSqlWorkloadCount, ...
+```
+
+Tab completion works best with unquoted, comma-separated values:
+
+```
+Get-RscType -Name ClusterConnection -InitialProperties Count,Nodes.I<tab>
+```
+
+For multi-line readability, use `@(...)` with each path quoted:
+
+```powershell
+$fields = Get-RscType -Name ClusterConnection -InitialProperties @(
+    "Nodes.Id"
+    "Nodes.Name"
+    "Nodes.Status"
+    "Nodes.GeoLocation.Address"
+)
+```
+
+### Inspecting the Field Spec
+
+Use `.AsFieldSpec()` to see the GraphQL field selection your object
+produces:
+
+```powershell
+$fields = Get-RscType -Name ClusterConnection -InitialProperties Nodes.Id,Nodes.Name
+$fields.AsFieldSpec()
+# nodes {
+#   id
+#   name
+# }
+```
+
+## Interface Fields: The `on:` Type Selector
+
+When a field is a `List<Interface>` (e.g. a Connection's `Nodes` field
+backed by a GraphQL interface), the SDK needs to know which implementing
+types to include as inline fragments (`... on TypeName`).
+
+### Default: All Implementing Types
+
+Without `on:`, all implementing types are included:
+
+```powershell
+$fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties Nodes.Id
+
+$fields.AsFieldSpec()
+# nodes {
+#   ... on MssqlAvailabilityGroup { id }
+#   ... on MssqlDatabase { id }
+#   ... on MssqlHost { id }
+#   ... on MssqlInstance { id }
+#   ... on PhysicalHost { id }
+#   ... on WindowsCluster { id }
+# }
+```
+
+This is usually more than you need.
+
+### Targeting Specific Types with `on:`
+
+Use `on:TypeName` after a `List<Interface>` field to include only that
+type:
+
+```powershell
+$fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties Nodes.on:PhysicalHost.Id
+
+$fields.AsFieldSpec()
+# nodes {
+#   ... on PhysicalHost { id }
+# }
+```
+
+### Multiple Types
+
+Specify multiple `on:` selectors for different types:
+
+```powershell
+$fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+    -InitialProperties @(
+        "Nodes.on:PhysicalHost.Id"
+        "Nodes.on:MssqlDatabase.Name"
+    )
+
+$fields.AsFieldSpec()
+# nodes {
+#   ... on PhysicalHost { id }
+#   ... on MssqlDatabase { name }
+# }
+```
+
+### Explicit All-Types
+
+`on:*` explicitly requests all implementing types (same as omitting
+`on:`, but self-documenting):
+
+```powershell
+"Nodes.on:*.Id"    # all types get id — same as "Nodes.Id"
+```
+
+### Nested Interfaces
+
+The `on:` syntax composes naturally across multiple interface levels:
+
+```powershell
+# PhysicalHost → physicalChildConnection → Nodes (another interface) → MssqlInstance
+$fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+    -InitialProperties @(
+        "Nodes.on:PhysicalHost.Id"
+        "Nodes.on:PhysicalHost.Name"
+        "Nodes.on:PhysicalHost.PhysicalChildConnection.Count"
+        "Nodes.on:PhysicalHost.PhysicalChildConnection.Nodes.on:MssqlInstance.Id"
+        "Nodes.on:PhysicalHost.PhysicalChildConnection.Nodes.on:MssqlInstance.Name"
+    )
+```
+
+This produces a field spec with exactly two inline fragments (PhysicalHost
+at the outer level, MssqlInstance at the inner level) — no other
+implementing types are included.
+
+### Tab Completion for `on:`
+
+After a `List<Interface>` field, tab completion shows type selectors
+instead of property names:
+
+```
+Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
+    -InitialProperties Nodes.<tab>
+# on:*
+# on:MssqlAvailabilityGroup
+# on:MssqlDatabase
+# on:MssqlHost
+# on:MssqlInstance
+# on:PhysicalHost
+# on:WindowsCluster
+```
+
+### The `on:` Prefix
+
+The `on:` prefix is borrowed from GraphQL's `... on Type` inline
+fragment syntax. It avoids ambiguity with property names (`:` never
+appears in .NET property names), so the parser always knows whether a
+dotted path segment is a type selector or a property lookup.
+
+## Using Field Specs with Queries
+
+Pass the field spec object to `New-RscQuery -Field` with
+`-FieldProfile EMPTY`:
+
+```powershell
+$fields = Get-RscType -Name ClusterConnection -InitialProperties Nodes.Id,Nodes.Name,Nodes.Status
+$result = New-RscQuery -Gql clusterConnection -Field $fields -FieldProfile EMPTY | Invoke-Rsc
+$result.Nodes | Select-Object Id, Name, Status
+```
+
+Without `-FieldProfile EMPTY`, the field spec is merged with AutoField's
+default selections (which may add fields you didn't ask for).
+
+## When to Use Which
+
+| Situation | Use |
+|-----------|-----|
+| Exploring the API, trying things out | AutoField (`New-RscQuery -Gql ...`) |
+| Quick scripts, ad-hoc queries | AutoField + `-AddField` / `-RemoveField` |
+| Production automation, CI/CD | Field Spec (`Get-RscType -InitialProperties`) |
+| Stable integration that shouldn't break on SDK updates | Field Spec |
+| Query with interface fields where you want specific types | Field Spec with `on:` |
+| You want the SDK to pick up new useful fields automatically | AutoField |
+
+## Related Documentation
+
+- [AutoField](./autofield.md) — automatic field selection profiles and patches
+- [Retrieving Interface Fields](./retrieving_interface_fields.md) — how
+  interfaces and composite objects work under the covers
+- [How To Create a Query](./HOWTO_create_a_query.md) — end-to-end query creation

--- a/docs/fieldspec.md
+++ b/docs/fieldspec.md
@@ -109,17 +109,44 @@ $fields.AsFieldSpec()
 
 ## Interface Fields: The `on:` Type Selector
 
-When a field is a `List<Interface>` (e.g. a Connection's `Nodes` field
-backed by a GraphQL interface), the SDK needs to know which implementing
-types to include as inline fragments (`... on TypeName`).
+Interfaces appear in three contexts in the RSC schema. The `on:` type
+selector works uniformly in all three:
 
-### Default: All Implementing Types
+| Context                | Example type / property                          | What `on:` does                         |
+|------------------------|--------------------------------------------------|-----------------------------------------|
+| **Root interface**     | `SlaDomain`                                      | Choose which implementing types to include in the composite |
+| **List\<Interface\>**  | `MssqlTopLevelDescendantTypeConnection.Nodes`    | Choose which inline fragments to emit   |
+| **Single interface**   | `MssqlDatabase.EffectiveSlaDomain`               | Choose which implementing type to instantiate |
 
-Without `on:`, all implementing types are included:
+### 1. Root Interface
+
+When the type passed to `-Name` is itself an interface:
 
 ```powershell
-$fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties Nodes.Id
+# Specific type — only GlobalSlaReply fragment
+$fields = Get-RscType -Name SlaDomain -InitialProperties on:GlobalSlaReply.Id
+$fields.AsFieldSpec()
+# ... on GlobalSlaReply { id }
 
+# Multiple types — one fragment per type
+$fields = Get-RscType -Name SlaDomain -InitialProperties on:ClusterSlaDomain.Id,on:GlobalSlaReply.UiColor
+$fields.AsFieldSpec()
+# ... on ClusterSlaDomain { id }
+# ... on GlobalSlaReply { uiColor }
+
+# All types
+$fields = Get-RscType -Name SlaDomain -InitialProperties on:*.Id
+```
+
+### 2. List\<Interface\>
+
+When a property is a `List<Interface>` (e.g. a Connection's `Nodes`
+field backed by a GraphQL interface), each `on:` selector becomes an
+inline fragment:
+
+```powershell
+# Default (no on:) — all implementing types
+$fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties Nodes.Id
 $fields.AsFieldSpec()
 # nodes {
 #   ... on MssqlAvailabilityGroup { id }
@@ -129,35 +156,20 @@ $fields.AsFieldSpec()
 #   ... on PhysicalHost { id }
 #   ... on WindowsCluster { id }
 # }
-```
 
-This is usually more than you need.
-
-### Targeting Specific Types with `on:`
-
-Use `on:TypeName` after a `List<Interface>` field to include only that
-type:
-
-```powershell
+# Specific type — only PhysicalHost
 $fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties Nodes.on:PhysicalHost.Id
-
 $fields.AsFieldSpec()
 # nodes {
 #   ... on PhysicalHost { id }
 # }
-```
 
-### Multiple Types
-
-Specify multiple `on:` selectors for different types:
-
-```powershell
+# Multiple types
 $fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
     -InitialProperties @(
         "Nodes.on:PhysicalHost.Id"
         "Nodes.on:MssqlDatabase.Name"
     )
-
 $fields.AsFieldSpec()
 # nodes {
 #   ... on PhysicalHost { id }
@@ -165,7 +177,21 @@ $fields.AsFieldSpec()
 # }
 ```
 
-### Explicit All-Types
+### 3. Single Interface Property
+
+When a property is a single interface (not a list):
+
+```powershell
+# Default (no on:) — picks the first implementing type (alphabetically)
+$fields = Get-RscType -Name MssqlDatabase -InitialProperties EffectiveSlaDomain.Name
+$fields.EffectiveSlaDomain.GetType().Name  # ClusterSlaDomain
+
+# Specific type — choose which implementing type to use
+$fields = Get-RscType -Name MssqlDatabase -InitialProperties EffectiveSlaDomain.on:GlobalSlaReply.UiColor
+$fields.EffectiveSlaDomain.GetType().Name  # GlobalSlaReply
+```
+
+### Explicit All-Types with `on:*`
 
 `on:*` explicitly requests all implementing types (same as omitting
 `on:`, but self-documenting):
@@ -196,20 +222,37 @@ implementing types are included.
 
 ### Tab Completion for `on:`
 
-After a `List<Interface>` field, tab completion shows type selectors
-instead of property names:
+Tab completion offers `on:` selectors whenever the current position is
+an interface — whether at root, after a `List<Interface>` field, or
+after a single interface property:
 
 ```
+Get-RscType -Name SlaDomain -InitialProperties <tab>
+# on:*  on:ClusterSlaDomain  on:GlobalSlaReply  ...
+
 Get-RscType -Name MssqlTopLevelDescendantTypeConnection `
     -InitialProperties Nodes.<tab>
-# on:*
-# on:MssqlAvailabilityGroup
-# on:MssqlDatabase
-# on:MssqlHost
-# on:MssqlInstance
-# on:PhysicalHost
-# on:WindowsCluster
+# on:*  on:MssqlAvailabilityGroup  on:MssqlDatabase  ...
+
+Get-RscType -Name MssqlDatabase -InitialProperties EffectiveSlaDomain.<tab>
+# on:*  on:ClusterSlaDomain  on:GlobalSlaReply  ...
 ```
+
+### Stability: `on:*` vs `on:TypeName`
+
+Using `on:*` (or omitting `on:` entirely) means your field spec includes
+**all** implementing types. If a future schema update adds a new type
+that implements the interface, your query automatically grows a new
+inline fragment — which may be what you want (exploration, ad-hoc
+queries) or may not (stable automation).
+
+This is the same trade-off that exists in GraphQL itself: a query like
+`{ pets { name } }` returns fragments for every type implementing `Pet`,
+and grows as the schema grows.
+
+For production scripts where you want full control over the query shape,
+prefer naming specific types with `on:TypeName`. Your query will only
+include the types you listed, regardless of schema changes.
 
 ### The `on:` Prefix
 


### PR DESCRIPTION
## Summary

- **Root interface `on:`**: `Get-RscType -Name SlaDomain -InitialProperties on:GlobalSlaReply.Id` — select specific implementing types when the root type is an interface (previously crashed)
- **Single interface property `on:`**: `EffectiveSlaDomain.on:GlobalSlaReply.UiColor` — choose which implementing type to use for single interface properties (previously always picked the first type alphabetically)
- **`*` wildcard**: `CloudInfo.*` sets all scalar properties on a nested object, avoiding verbose per-field enumeration
- **Tab completion**: offers `on:` selectors in all three interface contexts (root, `List<Interface>`, single interface property), stops at scalar leaves, and includes interface names in `-Name` completion
- **Bare interface instantiation**: `Get-RscType -Name SlaDomain` (no `-InitialProperties`) returns first implementing type instead of crashing

### The three interface contexts

```powershell
# Root interface
Get-RscType -Name SlaDomain -InitialProperties on:ClusterSlaDomain.Id

# List<Interface> (already worked before this PR)
Get-RscType -Name MssqlTopLevelDescendantTypeConnection -InitialProperties nodes.on:PhysicalHost.id

# Single interface property
Get-RscType -Name MssqlDatabase -InitialProperties EffectiveSlaDomain.on:GlobalSlaReply.UiColor

# * wildcard
Get-RscType -Name SlaDomain -InitialProperties on:GlobalSlaReply.SnapshotSchedule.Minute.BasicSchedule.*
```

## Test plan

- [x] `make clean && make build` — compiles on both net481 and net6.0
- [x] `make test` — all 169 tests pass (80 unit + 27 C# + 4 toolkit unit + 11 e2e + 47 toolkit e2e)
- [ ] Manual: verify tab completion for all three interface contexts
- [ ] Manual: verify `on:` produces correct `AsFieldSpec()` output with inline fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)