### PR TITLE
Auto-retry GraphQL queries that hit feature-flagged fields (403)

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client.Tests/FeatureFlagRetryTests.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client.Tests/FeatureFlagRetryTests.cs
@@ -1,0 +1,245 @@
+using GraphQL;
+using NUnit.Framework;
+using RubrikSecurityCloud.NetSDK.Client;
+using System.Collections.Generic;
+
+namespace RubrikSecurityCloud.Client.Tests
+{
+    [TestFixture]
+    public class FeatureFlagRetryTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            // Reset FieldsToSkip to defaults before each test
+            Config.FieldsToSkip = new HashSet<string>(
+                System.StringComparer.OrdinalIgnoreCase)
+            {
+                "CdmPendingObjectPauseAssignment",
+                "RscPendingObjectPauseAssignment"
+            };
+        }
+
+        // ── Helper to create GraphQLError ──────────────────────────
+
+        private static GraphQLError MakeError(
+            string message,
+            object code = null,
+            object[] path = null)
+        {
+            var error = new GraphQLError { Message = message };
+            if (code != null)
+            {
+                var map = new Map { { "code", code } };
+                error.Extensions = map;
+            }
+            if (path != null)
+            {
+                error.Path = new ErrorPath(path);
+            }
+            return error;
+        }
+
+        // ── IsFeatureFlagError ──────────────────────────────────────
+
+        [Test]
+        public void IsFeatureFlagError_IntCode403()
+        {
+            var error = MakeError("forbidden", code: 403);
+            Assert.IsTrue(RscGraphQLClient.IsFeatureFlagError(error));
+        }
+
+        [Test]
+        public void IsFeatureFlagError_StringCode403()
+        {
+            var error = MakeError("forbidden", code: "403");
+            Assert.IsTrue(RscGraphQLClient.IsFeatureFlagError(error));
+        }
+
+        [Test]
+        public void IsFeatureFlagError_Code500_ReturnsFalse()
+        {
+            var error = MakeError("server error", code: 500);
+            Assert.IsFalse(RscGraphQLClient.IsFeatureFlagError(error));
+        }
+
+        [Test]
+        public void IsFeatureFlagError_NoExtensions_ReturnsFalse()
+        {
+            var error = new GraphQLError { Message = "some error" };
+            Assert.IsFalse(RscGraphQLClient.IsFeatureFlagError(error));
+        }
+
+        [Test]
+        public void IsFeatureFlagError_NullError_ReturnsFalse()
+        {
+            Assert.IsFalse(RscGraphQLClient.IsFeatureFlagError(null));
+        }
+
+        // ── ClassifyErrors ──────────────────────────────────────────
+
+        [Test]
+        public void ClassifyErrors_AllFeatureFlag()
+        {
+            var errors = new[]
+            {
+                MakeError("ff1", code: 403),
+                MakeError("ff2", code: "403"),
+            };
+
+            RscGraphQLClient.ClassifyErrors(
+                errors,
+                out var featureFlagErrors,
+                out var otherErrors);
+
+            Assert.AreEqual(2, featureFlagErrors.Count);
+            Assert.AreEqual(0, otherErrors.Count);
+        }
+
+        [Test]
+        public void ClassifyErrors_MixedErrors()
+        {
+            var errors = new[]
+            {
+                MakeError("ff1", code: 403),
+                MakeError("real error", code: 500),
+            };
+
+            RscGraphQLClient.ClassifyErrors(
+                errors,
+                out var featureFlagErrors,
+                out var otherErrors);
+
+            Assert.AreEqual(1, featureFlagErrors.Count);
+            Assert.AreEqual(1, otherErrors.Count);
+        }
+
+        [Test]
+        public void ClassifyErrors_NoErrors()
+        {
+            RscGraphQLClient.ClassifyErrors(
+                null,
+                out var featureFlagErrors,
+                out var otherErrors);
+
+            Assert.AreEqual(0, featureFlagErrors.Count);
+            Assert.AreEqual(0, otherErrors.Count);
+        }
+
+        // ── ExtractFieldNamesFromErrors ─────────────────────────────
+
+        [Test]
+        public void ExtractFieldNames_SimpleLeafPath()
+        {
+            var errors = new List<GraphQLError>
+            {
+                MakeError("forbidden", code: 403,
+                    path: new object[] {
+                        "mssqlDatabaseLiveMounts", "nodes", "0",
+                        "sourceDatabase", "cdmPendingObjectPauseAssignment"
+                    })
+            };
+
+            var fields = RscGraphQLClient.ExtractFieldNamesFromErrors(errors);
+
+            Assert.AreEqual(1, fields.Count);
+            Assert.IsTrue(fields.Contains("cdmPendingObjectPauseAssignment"));
+        }
+
+        [Test]
+        public void ExtractFieldNames_PathEndingInNumericIndex()
+        {
+            var errors = new List<GraphQLError>
+            {
+                MakeError("forbidden", code: 403,
+                    path: new object[] { "items", "someField", "3" })
+            };
+
+            var fields = RscGraphQLClient.ExtractFieldNamesFromErrors(errors);
+
+            Assert.AreEqual(1, fields.Count);
+            Assert.IsTrue(fields.Contains("someField"));
+        }
+
+        [Test]
+        public void ExtractFieldNames_MultipleErrorsSameField()
+        {
+            var errors = new List<GraphQLError>
+            {
+                MakeError("ff1", code: 403,
+                    path: new object[] { "a", "0", "flagged" }),
+                MakeError("ff2", code: 403,
+                    path: new object[] { "b", "1", "flagged" }),
+            };
+
+            var fields = RscGraphQLClient.ExtractFieldNamesFromErrors(errors);
+
+            // Deduplicated
+            Assert.AreEqual(1, fields.Count);
+            Assert.IsTrue(fields.Contains("flagged"));
+        }
+
+        [Test]
+        public void ExtractFieldNames_MultipleDifferentFields()
+        {
+            var errors = new List<GraphQLError>
+            {
+                MakeError("ff1", code: 403,
+                    path: new object[] { "a", "fieldA" }),
+                MakeError("ff2", code: 403,
+                    path: new object[] { "b", "fieldB" }),
+            };
+
+            var fields = RscGraphQLClient.ExtractFieldNamesFromErrors(errors);
+
+            Assert.AreEqual(2, fields.Count);
+            Assert.IsTrue(fields.Contains("fieldA"));
+            Assert.IsTrue(fields.Contains("fieldB"));
+        }
+
+        [Test]
+        public void ExtractFieldNames_NullPath_Skipped()
+        {
+            var errors = new List<GraphQLError>
+            {
+                MakeError("ff1", code: 403, path: null)
+            };
+
+            var fields = RscGraphQLClient.ExtractFieldNamesFromErrors(errors);
+
+            Assert.AreEqual(0, fields.Count);
+        }
+
+        // ── Config.AddFieldToSkip integration ───────────────────────
+
+        [Test]
+        public void AddFieldToSkip_AddsToSet()
+        {
+            Assert.IsFalse(Config.FieldsToSkip.Contains("newField"));
+
+            Config.AddFieldToSkip("newField");
+
+            Assert.IsTrue(Config.FieldsToSkip.Contains("newField"));
+        }
+
+        [Test]
+        public void AddFieldToSkip_CaseInsensitive()
+        {
+            Config.AddFieldToSkip("MyField");
+
+            Assert.IsTrue(Config.FieldsToSkip.Contains("myfield"));
+            Assert.IsTrue(Config.FieldsToSkip.Contains("MYFIELD"));
+        }
+
+        [Test]
+        public void AddFieldToSkip_NullOrEmpty_NoOp()
+        {
+            int countBefore = Config.FieldsToSkip.Count;
+
+            Config.AddFieldToSkip(null);
+            Config.AddFieldToSkip("");
+
+            Assert.AreEqual(countBefore, Config.FieldsToSkip.Count);
+        }
+    }
+}

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/GraphQLClient.cs
@@ -323,10 +323,87 @@ namespace RubrikSecurityCloud.NetSDK.Client
                 localError = ex.Message;
             }
             logGraphQLResponse<T>(response, logger);
-            
+
             if (localError != null || response.Errors != null ||
                 response.StatusCode >= System.Net.HttpStatusCode.BadRequest)
             {
+                // Check if we can auto-retry by stripping feature-flagged fields
+                if (localError == null && response.Errors != null &&
+                    response.Data != null &&
+                    response.StatusCode < System.Net.HttpStatusCode.BadRequest)
+                {
+                    ClassifyErrors(
+                        response.Errors,
+                        out var featureFlagErrors,
+                        out var otherErrors);
+
+                    if (otherErrors.Count == 0 && featureFlagErrors.Count > 0)
+                    {
+                        var fieldsToStrip = ExtractFieldNamesFromErrors(
+                            featureFlagErrors);
+
+                        if (fieldsToStrip.Count > 0)
+                        {
+                            string fieldList = string.Join(", ", fieldsToStrip);
+                            string warnMsg =
+                                $"Auto-retrying query after stripping " +
+                                $"feature-flagged fields: [{fieldList}]. " +
+                                $"Consider upgrading the SDK.";
+                            if (RubrikSecurityCloud.Config.MuteSchemaWarnings)
+                            {
+                                logger?.Verbose(warnMsg);
+                            }
+                            else
+                            {
+                                logger?.Warning(warnMsg);
+                            }
+
+                            // Add to FieldsToSkip so subsequent queries
+                            // skip these fields proactively
+                            foreach (var f in fieldsToStrip)
+                            {
+                                RubrikSecurityCloud.Config.AddFieldToSkip(f);
+                            }
+
+                            // Strip fields from query and retry once
+                            string modifiedQuery =
+                                StringUtils.StripFieldsFromQuery(
+                                    Request.Query, fieldsToStrip);
+                            Request.Query = modifiedQuery;
+
+                            _apiCallCount++;
+                            logGraphQLRequest(Request, logger);
+                            GraphQL.Client.Http.GraphQLHttpResponse<T>
+                                retryResponse = null;
+                            string retryError = null;
+                            try
+                            {
+                                retryResponse =
+                                    (GraphQL.Client.Http.GraphQLHttpResponse<T>)
+                                    await graphQLClient
+                                        .SendQueryAsync<T>(Request);
+                            }
+                            catch (Exception ex)
+                            {
+                                retryError = ex.Message;
+                            }
+                            logGraphQLResponse<T>(retryResponse, logger);
+
+                            if (retryError == null &&
+                                (retryResponse.Errors == null ||
+                                 retryResponse.Errors.Length == 0) &&
+                                retryResponse.StatusCode <
+                                    System.Net.HttpStatusCode.BadRequest)
+                            {
+                                return retryResponse.Data;
+                            }
+                            // Retry failed — fall through to throw
+                            response = retryResponse;
+                            localError = retryError;
+                        }
+                    }
+                }
+
                 string msg = "The request generated an error.\n" +
                     this.GraphQLRequestToString(Request) + "\n\n" +
                     this.GraphQLResponseToString<T>(response) + "\n\n" +
@@ -339,6 +416,73 @@ namespace RubrikSecurityCloud.NetSDK.Client
             }
 
             return response.Data;
+        }
+
+        /// <summary>
+        /// Classify GraphQL errors into feature-flag (403) errors
+        /// and other errors.
+        /// </summary>
+        internal static void ClassifyErrors(
+            GraphQLError[] errors,
+            out List<GraphQLError> featureFlagErrors,
+            out List<GraphQLError> otherErrors)
+        {
+            featureFlagErrors = new List<GraphQLError>();
+            otherErrors = new List<GraphQLError>();
+
+            if (errors == null) return;
+
+            foreach (var e in errors)
+            {
+                if (IsFeatureFlagError(e))
+                {
+                    featureFlagErrors.Add(e);
+                }
+                else
+                {
+                    otherErrors.Add(e);
+                }
+            }
+        }
+
+        internal static bool IsFeatureFlagError(GraphQLError error)
+        {
+            if (error?.Extensions == null ||
+                !error.Extensions.ContainsKey("code"))
+            {
+                return false;
+            }
+            var code = error.Extensions["code"];
+            // Handle both int 403 and string "403"
+            return code?.ToString() == "403";
+        }
+
+        /// <summary>
+        /// Extract field names from 403 error paths.
+        /// The offending field is the last string element in the path
+        /// (numeric array indices are skipped).
+        /// Returns PascalCase names for Config.FieldsToSkip compatibility,
+        /// and also includes camelCase variants for query string stripping.
+        /// </summary>
+        internal static HashSet<string> ExtractFieldNamesFromErrors(
+            List<GraphQLError> errors)
+        {
+            var fields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var e in errors)
+            {
+                if (e.Path == null) continue;
+                // Walk backwards to find the last non-numeric element
+                for (int i = e.Path.Count - 1; i >= 0; i--)
+                {
+                    string segment = e.Path[i]?.ToString();
+                    if (string.IsNullOrEmpty(segment)) continue;
+                    // Skip numeric array indices
+                    if (int.TryParse(segment, out _)) continue;
+                    fields.Add(segment);
+                    break;
+                }
+            }
+            return fields;
         }
 
         private string GraphQLRequestToString(GraphQLRequest request)

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Client/RubrikSecurityCloud.Client.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Client/RubrikSecurityCloud.Client.csproj
@@ -10,6 +10,9 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="RubrikSecurityCloud.Client.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\RubrikSecurityCloud.Schema\RubrikSecurityCloud.Schema.csproj" />
     <ProjectReference Include="..\RubrikSecurityCloud.Common\RubrikSecurityCloud.Common.csproj" />
   </ItemGroup>

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/StripFieldsTests.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common.Tests/StripFieldsTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using RubrikSecurityCloud;
+
+namespace RubrikSecurityCloud.Tests
+{
+    [TestFixture]
+    public class StripFieldsTests
+    {
+        // ── Leaf field stripping ────────────────────────────────────
+
+        [Test]
+        public void StripLeafField()
+        {
+            string query =
+                "query Q {\n" +
+                "  a {\n" +
+                "    id\n" +
+                "    flaggedField\n" +
+                "    name\n" +
+                "  }\n" +
+                "}\n";
+
+            var fields = new HashSet<string> { "flaggedField" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.That(result, Does.Not.Contain("flaggedField"));
+            Assert.That(result, Does.Contain("id"));
+            Assert.That(result, Does.Contain("name"));
+        }
+
+        // ── Nested object field stripping ───────────────────────────
+
+        [Test]
+        public void StripNestedField()
+        {
+            string query =
+                "query Q {\n" +
+                "  nodes {\n" +
+                "    name\n" +
+                "    cdmPending {\n" +
+                "      status\n" +
+                "      reason\n" +
+                "    }\n" +
+                "    id\n" +
+                "  }\n" +
+                "}\n";
+
+            var fields = new HashSet<string> { "cdmPending" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.That(result, Does.Not.Contain("cdmPending"));
+            Assert.That(result, Does.Not.Contain("status"));
+            Assert.That(result, Does.Not.Contain("reason"));
+            Assert.That(result, Does.Contain("name"));
+            Assert.That(result, Does.Contain("id"));
+        }
+
+        // ── Field inside inline fragment ────────────────────────────
+
+        [Test]
+        public void StripFieldInsideInlineFragment()
+        {
+            string query =
+                "query Q {\n" +
+                "  data {\n" +
+                "    ... on VsphereVm {\n" +
+                "      name\n" +
+                "      flaggedField\n" +
+                "      id\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
+
+            var fields = new HashSet<string> { "flaggedField" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.That(result, Does.Not.Contain("flaggedField"));
+            Assert.That(result, Does.Contain("name"));
+            Assert.That(result, Does.Contain("id"));
+            Assert.That(result, Does.Contain("... on VsphereVm"));
+        }
+
+        // ── Multiple fields stripped at once ────────────────────────
+
+        [Test]
+        public void StripMultipleFields()
+        {
+            string query =
+                "query Q {\n" +
+                "  a\n" +
+                "  fieldOne\n" +
+                "  b\n" +
+                "  fieldTwo {\n" +
+                "    x\n" +
+                "  }\n" +
+                "  c\n" +
+                "}\n";
+
+            var fields = new HashSet<string> { "fieldOne", "fieldTwo" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.That(result, Does.Not.Contain("fieldOne"));
+            Assert.That(result, Does.Not.Contain("fieldTwo"));
+            Assert.That(result, Does.Contain("a"));
+            Assert.That(result, Does.Contain("b"));
+            Assert.That(result, Does.Contain("c"));
+        }
+
+        // ── No-op when field not present ────────────────────────────
+
+        [Test]
+        public void NoOpWhenFieldNotPresent()
+        {
+            string query =
+                "query Q {\n" +
+                "  id\n" +
+                "  name\n" +
+                "}\n";
+
+            var fields = new HashSet<string> { "nonExistentField" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.AreEqual(query, result);
+        }
+
+        // ── Field name inside string literal is NOT stripped ────────
+
+        [Test]
+        public void FieldNameInStringLiteralNotStripped()
+        {
+            string query =
+                "mutation M {\n" +
+                "  createThing(name: \"flaggedField\") {\n" +
+                "    id\n" +
+                "  }\n" +
+                "}\n";
+
+            var fields = new HashSet<string> { "flaggedField" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            // The string literal should be preserved
+            Assert.That(result, Does.Contain("\"flaggedField\""));
+            Assert.That(result, Does.Contain("id"));
+        }
+
+        // ── Field with __typename suffix ────────────────────────────
+
+        [Test]
+        public void StripFieldWithTypename()
+        {
+            // After InsertTypeNamesInGqlQuery, fields inside braces have __typename
+            string query =
+                "query Q {\n" +
+                "  nodes {\n" +
+                "    name\n" +
+                "    cdmPending {\n" +
+                "      status __typename }\n" +
+                "    id\n" +
+                "  __typename }\n" +
+                "__typename }\n";
+
+            var fields = new HashSet<string> { "cdmPending" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.That(result, Does.Not.Contain("cdmPending"));
+            Assert.That(result, Does.Not.Contain("status"));
+            Assert.That(result, Does.Contain("name"));
+            Assert.That(result, Does.Contain("id"));
+            // The outer __typename entries should remain
+            Assert.That(result, Does.Contain("__typename"));
+        }
+
+        // ── Case-insensitive matching ───────────────────────────────
+
+        [Test]
+        public void CaseInsensitiveFieldMatch()
+        {
+            string query =
+                "query Q {\n" +
+                "  CdmPendingObjectPauseAssignment\n" +
+                "  name\n" +
+                "}\n";
+
+            // Field in the set is camelCase, query has PascalCase
+            var fields = new HashSet<string> { "cdmPendingObjectPauseAssignment" };
+            string result = StringUtils.StripFieldsFromQuery(query, fields);
+
+            Assert.That(result, Does.Not.Contain("CdmPendingObjectPauseAssignment"));
+            Assert.That(result, Does.Contain("name"));
+        }
+
+        // ── Empty/null inputs ───────────────────────────────────────
+
+        [Test]
+        public void NullQueryReturnsNull()
+        {
+            string result = StringUtils.StripFieldsFromQuery(
+                null, new HashSet<string> { "x" });
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void EmptyFieldSetReturnsQueryUnchanged()
+        {
+            string query = "query Q { id name }";
+            string result = StringUtils.StripFieldsFromQuery(
+                query, new HashSet<string>());
+            Assert.AreEqual(query, result);
+        }
+
+        // ── ToCamelCase helper ──────────────────────────────────────
+
+        [Test]
+        public void ToCamelCase_PascalCase()
+        {
+            Assert.AreEqual(
+                "cdmPendingObjectPauseAssignment",
+                StringUtils.ToCamelCase("CdmPendingObjectPauseAssignment"));
+        }
+
+        [Test]
+        public void ToCamelCase_AlreadyCamelCase()
+        {
+            Assert.AreEqual(
+                "fieldName",
+                StringUtils.ToCamelCase("fieldName"));
+        }
+
+        [Test]
+        public void ToCamelCase_Acronym()
+        {
+            Assert.AreEqual("cdmFoo", StringUtils.ToCamelCase("CDMFoo"));
+        }
+
+        [Test]
+        public void ToCamelCase_AllCaps()
+        {
+            Assert.AreEqual("cpu", StringUtils.ToCamelCase("CPU"));
+        }
+    }
+}

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common/Config.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common/Config.cs
@@ -47,14 +47,33 @@ namespace RubrikSecurityCloud
         public static uint ApiClientTimeOutMinutes = 6;
 
         /// <summary>
-        /// List of fields that should be not be selected for consumption
+        /// List of fields that should be not be selected for consumption.
+        /// Fields are added here statically (known UFF fields) and
+        /// dynamically at runtime when the SDK retries a query after
+        /// encountering 403 feature-flag errors.
         /// </summary>
         /// TODO (SPARK-548179): Unskip these fields once it reaches GA.
-        public static readonly HashSet<string> FieldsToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        public static HashSet<string> FieldsToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "CdmPendingObjectPauseAssignment",
             "RscPendingObjectPauseAssignment"
         };
+
+        private static readonly object _fieldsToSkipLock = new object();
+
+        /// <summary>
+        /// Thread-safe addition of a field to the skip list.
+        /// Called automatically when the SDK retries a query after
+        /// a 403 feature-flag error.
+        /// </summary>
+        public static void AddFieldToSkip(string fieldName)
+        {
+            if (string.IsNullOrEmpty(fieldName)) return;
+            lock (_fieldsToSkipLock)
+            {
+                FieldsToSkip.Add(fieldName);
+            }
+        }
 
         /// <summary>
         /// Default profile leaf pattern. Keys are patterns to match against

--- a/RubrikSecurityCloud/RubrikSecurityCloud.Common/StringUtils.cs
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.Common/StringUtils.cs
@@ -338,6 +338,217 @@ namespace RubrikSecurityCloud
             }
         }
 
+        /// <summary>
+        /// Convert a PascalCase .NET name to camelCase GQL field name.
+        /// E.g. "CdmPendingObjectPauseAssignment" → "cdmPendingObjectPauseAssignment"
+        /// </summary>
+        public static string ToCamelCase(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+            if (char.IsLower(name[0])) return name;
+            // Lowercase leading uppercase chars (handle acronyms like "CDM" → "cdm")
+            int i = 0;
+            while (i < name.Length && char.IsUpper(name[i])) i++;
+            if (i == 1)
+            {
+                return char.ToLower(name[0]) + name.Substring(1);
+            }
+            // Multiple uppercase: lowercase all but the last (e.g. "CDMFoo" → "cdmFoo")
+            if (i == name.Length)
+            {
+                return name.ToLower();
+            }
+            return name.Substring(0, i - 1).ToLower() + name.Substring(i - 1);
+        }
+
+        /// <summary>
+        /// Remove specified fields from a GraphQL query string.
+        /// Handles leaf fields, nested object fields (brace-balanced),
+        /// and fields with __typename suffixes.
+        /// Field names should be in camelCase (GQL naming convention).
+        /// </summary>
+        public static string StripFieldsFromQuery(
+            string query,
+            HashSet<string> fieldNames)
+        {
+            if (string.IsNullOrEmpty(query) || fieldNames == null || fieldNames.Count == 0)
+            {
+                return query;
+            }
+
+            // Build a case-insensitive set for matching
+            var fieldsToStrip = new HashSet<string>(
+                fieldNames, StringComparer.OrdinalIgnoreCase);
+
+            var result = new StringBuilder();
+            int pos = 0;
+
+            while (pos < query.Length)
+            {
+                // Try to match a field name at current position
+                // Fields appear after whitespace/newlines, possibly indented
+                if (IsFieldStart(query, pos))
+                {
+                    string fieldName = ReadIdentifier(query, pos);
+                    if (fieldName != null && fieldsToStrip.Contains(fieldName))
+                    {
+                        // Skip this field — determine if it's a leaf or nested
+                        int fieldEnd = pos + fieldName.Length;
+                        fieldEnd = SkipWhitespace(query, fieldEnd);
+
+                        if (fieldEnd < query.Length && query[fieldEnd] == '{')
+                        {
+                            // Nested field — skip the entire brace-balanced block
+                            fieldEnd = SkipBraceBlock(query, fieldEnd);
+                        }
+                        // Also skip trailing __typename if present
+                        int afterWs = SkipWhitespace(query, fieldEnd);
+                        if (afterWs + 10 <= query.Length &&
+                            query.Substring(afterWs, 10) == "__typename")
+                        {
+                            fieldEnd = afterWs + 10;
+                        }
+                        // Skip trailing whitespace/newline after the stripped field
+                        while (fieldEnd < query.Length &&
+                               (query[fieldEnd] == ' ' || query[fieldEnd] == '\t'))
+                        {
+                            fieldEnd++;
+                        }
+                        if (fieldEnd < query.Length && query[fieldEnd] == '\n')
+                        {
+                            fieldEnd++;
+                        }
+
+                        // Trim trailing whitespace on the line we're appending to
+                        // (removes the indentation that preceded the stripped field)
+                        TrimTrailingWhitespace(result);
+                        if (result.Length > 0 && result[result.Length - 1] != '\n')
+                        {
+                            result.Append('\n');
+                        }
+
+                        pos = fieldEnd;
+                        continue;
+                    }
+                }
+
+                // Skip over string literals without scanning for field names
+                if (query[pos] == '"')
+                {
+                    result.Append(query[pos]);
+                    pos++;
+                    while (pos < query.Length)
+                    {
+                        result.Append(query[pos]);
+                        if (query[pos] == '"' && query[pos - 1] != '\\')
+                        {
+                            pos++;
+                            break;
+                        }
+                        pos++;
+                    }
+                    continue;
+                }
+
+                // Skip over parenthesized argument blocks
+                if (query[pos] == '(')
+                {
+                    int depth = 0;
+                    while (pos < query.Length)
+                    {
+                        result.Append(query[pos]);
+                        if (query[pos] == '(') depth++;
+                        else if (query[pos] == ')') { depth--; if (depth == 0) { pos++; break; } }
+                        pos++;
+                    }
+                    continue;
+                }
+
+                result.Append(query[pos]);
+                pos++;
+            }
+
+            return result.ToString();
+        }
+
+        private static bool IsFieldStart(string query, int pos)
+        {
+            // A field starts at position pos if:
+            // 1. pos is at the start, or preceded by whitespace/newline/{
+            // 2. The character at pos is a letter (start of identifier)
+            if (!char.IsLetter(query[pos])) return false;
+            if (pos == 0) return true;
+            char prev = query[pos - 1];
+            return prev == ' ' || prev == '\t' || prev == '\n' || prev == '\r' || prev == '{';
+        }
+
+        private static string ReadIdentifier(string query, int pos)
+        {
+            int start = pos;
+            while (pos < query.Length && (char.IsLetterOrDigit(query[pos]) || query[pos] == '_'))
+            {
+                pos++;
+            }
+            if (pos == start) return null;
+            string id = query.Substring(start, pos - start);
+            // Don't match keywords/special tokens
+            if (id == "__typename" || id == "query" || id == "mutation" ||
+                id == "fragment" || id == "on" || id == "subscription")
+            {
+                return null;
+            }
+            return id;
+        }
+
+        private static int SkipWhitespace(string query, int pos)
+        {
+            while (pos < query.Length &&
+                   (query[pos] == ' ' || query[pos] == '\t' ||
+                    query[pos] == '\n' || query[pos] == '\r'))
+            {
+                pos++;
+            }
+            return pos;
+        }
+
+        private static int SkipBraceBlock(string query, int pos)
+        {
+            // pos should be at '{'
+            int depth = 0;
+            bool inString = false;
+            while (pos < query.Length)
+            {
+                char c = query[pos];
+                if (c == '"' && (pos == 0 || query[pos - 1] != '\\'))
+                {
+                    inString = !inString;
+                }
+                if (!inString)
+                {
+                    if (c == '{') depth++;
+                    else if (c == '}')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            return pos + 1; // past the closing '}'
+                        }
+                    }
+                }
+                pos++;
+            }
+            return pos; // unbalanced — return end
+        }
+
+        private static void TrimTrailingWhitespace(StringBuilder sb)
+        {
+            while (sb.Length > 0 &&
+                   (sb[sb.Length - 1] == ' ' || sb[sb.Length - 1] == '\t'))
+            {
+                sb.Length--;
+            }
+        }
+
         public static (string, string) ParseGqlAndVarString(string query)
         {
             // Regular expression to match the /**/ block


### PR DESCRIPTION
## Summary
- Auto-retry GraphQL queries when the api-server returns 403 errors for feature-flagged fields
- Strip offending fields from the query string and retry once, preserving valid partial data
- Persist stripped fields in `Config.FieldsToSkip` so subsequent queries skip them proactively
- Add `StripFieldsFromQuery()` utility with brace-balanced field removal
- Add 29 new tests covering field stripping, error classification, and retry behavior

## Problem
When autofield builds a GraphQL query, it may include fields behind unreleased feature flags (UFF). The api-server returns HTTP 200 with **partial valid data** plus `errors[]` with `extensions.code == 403`. The SDK was throwing on ANY `response.Errors != null`, discarding the valid partial data entirely. Users had to manually add fields to `Config.FieldsToSkip` — which required knowing the field name up front.

## Changes

| File | Change |
|------|--------|
| `GraphQLClient.cs` | Classify errors (403 vs other), extract field names from error paths, strip from query, retry once, log warnings |
| `StringUtils.cs` | Add `StripFieldsFromQuery()` (brace-balanced field removal) and `ToCamelCase()` |
| `Config.cs` | Make `FieldsToSkip` mutable, add thread-safe `AddFieldToSkip()` |
| `RubrikSecurityCloud.Client.csproj` | Add `InternalsVisibleTo` for test access |
| `StripFieldsTests.cs` | 13 tests: leaf/nested/inline-fragment stripping, case-insensitive, edge cases |
| `FeatureFlagRetryTests.cs` | 16 tests: error classification, field extraction, Config integration |

## How it works
1. Query is sent to api-server
2. If response has errors, classify each as "feature-flag 403" vs "real error"
3. If **only** 403 errors exist and `response.Data != null`:
   - Extract field names from error paths (last non-numeric path segment)
   - Strip those fields from the query string
   - Add them to `Config.FieldsToSkip` for session-level caching
   - Log stripped fields as verbose/warning (respects `MuteSchemaWarnings`)
   - Retry the modified query once
4. If mixed errors or retry fails, throw as before

## Test plan
- [x] 13 field-stripping unit tests pass
- [x] 16 error classification / retry tests pass
- [x] 26 existing enum converter tests still pass
- [x] All 41 Common tests pass
- [x] Manual: connect to RSC instance with newer schema, verify auto-retry with verbose log

Closes #242
