### PR TITLE
Fix module import not restoring working directory (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 New Features:
 
 Fixes:
+- Fix module import not restoring the original working directory (#198)
 
 Breaking Changes:
 

--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/LoadModule.psm1
@@ -1,10 +1,10 @@
 #
 # Load Core DLL:
 #
+# Record the user's current working directory so that we can return to it when we
+# are done loading the module
+$currentPath = Get-Location
 try {
-    # Record the user's current working directory so that we can return to it when we 
-    # are done loading the module
-    $currentPath = Get-Location
 
     # Determine the module directory based on the PowerShell edition
     If ($PSVersionTable.PSEdition -eq "Desktop") {


### PR DESCRIPTION
## Summary
- Move `$currentPath = Get-Location` from inside `try{}` to before it in `LoadModule.psm1`
- This fixes PowerShell variable scoping: `$currentPath` was invisible in the `finally{}` block, so `Set-Location $currentPath` resolved to `$null` and the working directory was never restored after module import

Closes #198

## Test plan
- [ ] `make build`
- [ ] In a fresh PowerShell session: `cd /tmp; Import-Module ./Output/RubrikSecurityCloud/RubrikSecurityCloud.psd1; (Get-Location).Path` — should be `/tmp`
- [ ] `make test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)