### PR TITLE
Fix Get-RscEventSeries -Detail GraphQL validation error (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ New Features:
 
 Fixes:
 - Fix module import not restoring the original working directory (#198)
+- Fix `Get-RscEventSeries -Detail` failing with GraphQL validation error
+  due to required arguments on cluster sub-fields (#208)
 
 Breaking Changes:
 

--- a/Toolkit/Operations/DETAIL/QueryActivitySeries.patch
+++ b/Toolkit/Operations/DETAIL/QueryActivitySeries.patch
@@ -1,0 +1,6 @@
+-cluster.activitySeriesConnection
+-cluster.clusterDiskConnection
+-cluster.clusterNodeConnection
+-cluster.snappableConnection
+-cluster.metricTimeSeriesNew
+-cluster.clusterNodeStats

--- a/Toolkit/Operations/DETAIL/QueryActivitySeriesConnection.patch
+++ b/Toolkit/Operations/DETAIL/QueryActivitySeriesConnection.patch
@@ -1,0 +1,6 @@
+-nodes.cluster.activitySeriesConnection
+-nodes.cluster.clusterDiskConnection
+-nodes.cluster.clusterNodeConnection
+-nodes.cluster.snappableConnection
+-nodes.cluster.metricTimeSeriesNew
+-nodes.cluster.clusterNodeStats

--- a/Toolkit/Tests/unit/Get-RscEventSeries.Tests.ps1
+++ b/Toolkit/Tests/unit/Get-RscEventSeries.Tests.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+Tests for Get-RscEventSeries, including the -Detail flag fix (#208).
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name "Get-RscEventSeries" -Fixture {
+
+    It -Name 'Default query generates valid GQL' -Test {
+        $query = Get-RscEventSeries -First 1 -AsQuery
+        $query | Should -Not -BeNullOrEmpty
+        $gql = $query.GqlRequest().Query
+        $gql | Should -Match 'activitySeriesConnection'
+    }
+
+    It -Name 'Detail query by Id generates valid GQL' -Test {
+        $query = Get-RscEventSeries -Id '00000000-0000-0000-0000-000000000000' -Detail -AsQuery
+        $query | Should -Not -BeNullOrEmpty
+        $gql = $query.GqlRequest().Query
+        $gql | Should -Match 'activitySeries'
+    }
+
+    It -Name 'Detail query does not include metricTimeSeriesNew (#208)' -Test {
+        # Single-item query (QueryActivitySeries)
+        $query = Get-RscEventSeries -Id '00000000-0000-0000-0000-000000000000' -Detail -AsQuery
+        $gql = $query.GqlRequest().Query
+        $gql | Should -Not -Match 'metricTimeSeriesNew'
+
+        # List query (QueryActivitySeriesConnection)
+        $queryList = Get-RscEventSeries -First 1 -Detail -AsQuery
+        $gqlList = $queryList.GqlRequest().Query
+        $gqlList | Should -Not -Match 'metricTimeSeriesNew'
+    }
+}


### PR DESCRIPTION
## Summary
- `Get-RscEventSeries -Id $id -Detail` fails with a 400 error: `Expected type 'TimeUnitEnum!', found 'null'`
- The DETAIL field profile auto-selects the full `cluster` subgraph, which includes `metricTimeSeriesNew(unit: TimeUnitEnum!)` — a field with a required argument that gets passed as `null`
- Add DETAIL operation patches to exclude `metricTimeSeriesNew`, `clusterNodeStats`, and heavy connection sub-fields from both `QueryActivitySeries` and `QueryActivitySeriesConnection`
- Add unit test verifying the DETAIL query does not include `metricTimeSeriesNew`

Closes #208

## Test plan
- [ ] `make build`
- [ ] Run new unit test: `Invoke-Pester Toolkit/Tests/unit/Get-RscEventSeries.Tests.ps1`
- [ ] Manual: `Get-RscEventSeries -Id $id -Detail` should succeed without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)