### PR TITLE
Fix get rsc mssql instance cmdlet issue

### DIFF
--- a/Toolkit/Format/PhysicalHost.Format.ps1xml
+++ b/Toolkit/Format/PhysicalHost.Format.ps1xml
@@ -5,6 +5,7 @@
                 <Name>Default</Name>
                 <ViewSelectedBy>
                     <TypeName>RubrikSecurityCloud.Types.PhysicalHost</TypeName>
+                    <TypeName>RubrikSecurityCloud.Types.MssqlHost</TypeName>
                 </ViewSelectedBy>
                 <TableControl>
                     <TableHeaders>

--- a/Toolkit/Public/Get-RscMssqlInstance.ps1
+++ b/Toolkit/Public/Get-RscMssqlInstance.ps1
@@ -202,6 +202,7 @@ Return the query object instead of executing it.
 
             $physicalHostIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "PhysicalHost"})
             $windowsClusterIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "WindowsCluster"})
+            $mssqlHostIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlHost"})
 
             $query.field.Nodes[$physicalHostIndex].cluster = Get-RscType -Name Cluster -InitialProperties name,id
             $query.Field.Nodes[$physicalHostIndex].Vars.descendantConnection.typeFilter = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::MSSQL_INSTANCE
@@ -213,7 +214,22 @@ Return the query object instead of executing it.
             $query.field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].id = "FETCH"
             $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster = Get-RscType -Name Cluster -InitialProperties Name, Id
             $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties Name, Id
-            
+
+            # MssqlHost is the new HierarchyOverlapFix top-level type. The authz
+            # service registers MSSQL_HOST -> MSSQL_INSTANCE as a child edge
+            # (physicalChildConnection returns the instances) but not as a
+            # descendant edge (descendantConnection comes back empty). Wire the
+            # physicalChildConnection here so MssqlHost rows surface instances.
+            $query.field.Nodes[$mssqlHostIndex].cluster = Get-RscType -Name Cluster -InitialProperties name,id
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection = New-Object -TypeName RubrikSecurityCloud.Types.MssqlHostPhysicalChildTypeConnection
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection.nodes = New-Object -TypeName RubrikSecurityCloud.Types.MssqlInstance
+
+            $mssqlInstanceIndex = $query.field.nodes[$mssqlHostIndex].physicalChildConnection.Nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlInstance"})
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].name = "FETCH"
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].id = "FETCH"
+            $query.Field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].Cluster = Get-RscType -Name Cluster -InitialProperties Name, Id
+            $query.Field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties Name, Id
+
             $query.Field.Nodes[$windowsClusterIndex].cluster = Get-RscType -Name Cluster -InitialProperties name,id
             $query.Field.Nodes[$windowsClusterIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties name,id
             $query.Field.Nodes[$windowsClusterIndex].Vars.descendantConnection.typeFilter = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::MSSQL_INSTANCE
@@ -233,9 +249,29 @@ Return the query object instead of executing it.
                 $results = Invoke-Rsc $query
 
                 # If we passed in a specific host or windows cluster name, we return the instances from that host, otherwise, we return the host and windows cluster objects.
-                # I'm not a fan of this as returning mixed object types results in bad formatting and goes against 
                 if ($HostName -or $WindowsClusterName) {
-                    $results.nodes.descendantConnection.nodes
+                    # Collect MssqlInstance children from each top-level row.
+                    # PhysicalHost / WindowsCluster expose them via
+                    # descendantConnection. MssqlHost exposes them via
+                    # physicalChildConnection. Both returns MssqlInstance Type,
+                    # so create a generic List of type  RubrikSecurityCloud.Types.MssqlInstance.
+                    $instances = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.MssqlInstance]'
+                    $seenIds   = New-Object -TypeName 'System.Collections.Generic.HashSet[string]'
+
+                    foreach ($node in $results.nodes) {
+                        $childNodes = switch ($node.GetType().Name) {
+                            "PhysicalHost"   { $node.descendantConnection.nodes }
+                            "WindowsCluster" { $node.descendantConnection.nodes }
+                            "MssqlHost"      { $node.physicalChildConnection.nodes }
+                        }
+                        foreach ($child in $childNodes) {
+                            if ($child -is [RubrikSecurityCloud.Types.MssqlInstance] -and $seenIds.Add($child.id)) {
+                                $instances.Add($child)
+                            }
+                        }
+                    }
+
+                    return $instances
                 }
                 else {
                     $results.nodes

--- a/Toolkit/Tests/unit/Baselines/Get-RscMssqlInstance.ps1
+++ b/Toolkit/Tests/unit/Baselines/Get-RscMssqlInstance.ps1
@@ -202,6 +202,7 @@ Return the query object instead of executing it.
 
             $physicalHostIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "PhysicalHost"})
             $windowsClusterIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "WindowsCluster"})
+            $mssqlHostIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlHost"})
 
             $query.field.Nodes[$physicalHostIndex].cluster = Get-RscType -Name Cluster -InitialProperties name,id
             $query.Field.Nodes[$physicalHostIndex].Vars.descendantConnection.typeFilter = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::MSSQL_INSTANCE
@@ -211,13 +212,24 @@ Return the query object instead of executing it.
             $mssqlInstanceIndex = $query.field.nodes[$physicalHostIndex].descendantConnection.Nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlInstance"})
             $query.field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].name = "FETCH"
             $query.field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].id = "FETCH"
-            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster = New-Object RubrikSecurityCloud.Types.Cluster
-            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster.name = "FETCH"
-            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster.id = "FETCH"
-            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = New-Object -TypeName RubrikSecurityCloud.Types.GlobalSlaReply
-            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain.name = "FETCH"
-            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain.id = "FETCH"
-            
+            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster = Get-RscType -Name Cluster -InitialProperties Name, Id
+            $query.Field.Nodes[$physicalHostIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties Name, Id
+
+            # MssqlHost is the new HierarchyOverlapFix top-level type. The authz
+            # service registers MSSQL_HOST -> MSSQL_INSTANCE as a child edge
+            # (physicalChildConnection returns the instances) but not as a
+            # descendant edge (descendantConnection comes back empty). Wire the
+            # physicalChildConnection here so MssqlHost rows surface instances.
+            $query.field.Nodes[$mssqlHostIndex].cluster = Get-RscType -Name Cluster -InitialProperties name,id
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection = New-Object -TypeName RubrikSecurityCloud.Types.MssqlHostPhysicalChildTypeConnection
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection.nodes = New-Object -TypeName RubrikSecurityCloud.Types.MssqlInstance
+
+            $mssqlInstanceIndex = $query.field.nodes[$mssqlHostIndex].physicalChildConnection.Nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlInstance"})
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].name = "FETCH"
+            $query.field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].id = "FETCH"
+            $query.Field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].Cluster = Get-RscType -Name Cluster -InitialProperties Name, Id
+            $query.Field.Nodes[$mssqlHostIndex].physicalChildConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties Name, Id
+
             $query.Field.Nodes[$windowsClusterIndex].cluster = Get-RscType -Name Cluster -InitialProperties name,id
             $query.Field.Nodes[$windowsClusterIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties name,id
             $query.Field.Nodes[$windowsClusterIndex].Vars.descendantConnection.typeFilter = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::MSSQL_INSTANCE
@@ -225,10 +237,8 @@ Return the query object instead of executing it.
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes = New-Object -TypeName RubrikSecurityCloud.Types.MssqlInstance
 
             $mssqlInstanceIndex = $query.field.nodes[$windowsClusterIndex].descendantConnection.Nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlInstance"})
-            $query.Field.Nodes[$windowsClusterIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster = Get-RscType -Name Cluster -InitialProperties name,Id
-            $query.Field.Nodes[$windowsClusterIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = New-Object -TypeName RubrikSecurityCloud.Types.GlobalSlaReply
-            $query.Field.Nodes[$windowsClusterIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain.name = "FETCH"
-            $query.Field.Nodes[$windowsClusterIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain.id = "FETCH"
+            $query.Field.Nodes[$windowsClusterIndex].descendantConnection.Nodes[$mssqlInstanceIndex].Cluster = Get-RscType -Name Cluster -InitialProperties Name, Id
+            $query.Field.Nodes[$windowsClusterIndex].descendantConnection.Nodes[$mssqlInstanceIndex].effectiveSlaDomain = Get-RscType -Name GlobalSlaReply -InitialProperties Name, Id
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes[$mssqlInstanceIndex].name = "FETCH"
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes[$mssqlInstanceIndex].id = "FETCH"
 
@@ -239,9 +249,29 @@ Return the query object instead of executing it.
                 $results = Invoke-Rsc $query
 
                 # If we passed in a specific host or windows cluster name, we return the instances from that host, otherwise, we return the host and windows cluster objects.
-                # I'm not a fan of this as returning mixed object types results in bad formatting and goes against 
                 if ($HostName -or $WindowsClusterName) {
-                    $results.nodes.descendantConnection.nodes
+                    # Collect MssqlInstance children from each top-level row.
+                    # PhysicalHost / WindowsCluster expose them via
+                    # descendantConnection. MssqlHost exposes them via
+                    # physicalChildConnection. Both returns MssqlInstance Type,
+                    # so create a generic List of type  RubrikSecurityCloud.Types.MssqlInstance.
+                    $instances = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.MssqlInstance]'
+                    $seenIds   = New-Object -TypeName 'System.Collections.Generic.HashSet[string]'
+
+                    foreach ($node in $results.nodes) {
+                        $childNodes = switch ($node.GetType().Name) {
+                            "PhysicalHost"   { $node.descendantConnection.nodes }
+                            "WindowsCluster" { $node.descendantConnection.nodes }
+                            "MssqlHost"      { $node.physicalChildConnection.nodes }
+                        }
+                        foreach ($child in $childNodes) {
+                            if ($child -is [RubrikSecurityCloud.Types.MssqlInstance] -and $seenIds.Add($child.id)) {
+                                $instances.Add($child)
+                            }
+                        }
+                    }
+
+                    return $instances
                 }
                 else {
                     $results.nodes

--- a/Toolkit/Tests/unit/Get-RscMssqlInstance.Tests.ps1
+++ b/Toolkit/Tests/unit/Get-RscMssqlInstance.Tests.ps1
@@ -1,0 +1,136 @@
+#Requires -Version 3
+<#
+.SYNOPSIS
+    Unit tests for Get-RscMssqlInstance response flattening logic.
+
+.DESCRIPTION
+    Mocks Invoke-Rsc to return a synthetic mssqlTopLevelDescendants response
+    containing PhysicalHost, MssqlHost, and WindowsCluster top-level rows.
+    Verifies the wrapper:
+      - dispatches on ObjectType to the right connection
+        (descendantConnection for PhysicalHost / WindowsCluster,
+         physicalChildConnection for MssqlHost — authz lacks the descendant
+         edge for MSSQL_HOST -> MSSQL_INSTANCE under HierarchyOverlapFix)
+      - filters non-MssqlInstance children out of the result
+      - dedupes when the same instance appears via multiple parents
+        (HierarchyOverlapFix can return the same host as both PhysicalHost
+         and MssqlHost in a single response)
+
+    SDK module-loading note: PublicFunctions.psm1 imports each Toolkit/Public
+    *.ps1 wrapper via Import-Module, which puts the function body in a private
+    dynamic module scope that Pester cannot reach with `-ModuleName`. To make
+    `Mock Invoke-Rsc` actually intercept, we dot-source the wrapper file
+    directly into this test's scope below — the function is then defined
+    locally and calls Invoke-Rsc through the test scope where the mock lives.
+
+    Fixtures are built INSIDE each Mock scriptblock rather than in BeforeAll.
+    Pester v5 executes Mock bodies in their own scope, and closing over
+    Describe/BeforeAll variables can silently yield $null.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+
+    # Re-define Get-RscMssqlInstance in THIS scope so Mock Invoke-Rsc
+    # (registered without -ModuleName) is visible to its calls.
+    . "$PSScriptRoot\..\..\Public\Get-RscMssqlInstance.ps1"
+}
+
+Describe 'Get-RscMssqlInstance -HostName response flattening' {
+
+    BeforeAll {
+        Mock Invoke-Rsc -MockWith {
+            # Three MssqlInstance fixtures with stable ids.
+            $inst1 = New-Object RubrikSecurityCloud.Types.MssqlInstance
+            $inst1.Id = 'inst-1'
+            $inst1.Name = 'INSTANCE-1'
+
+            $inst2 = New-Object RubrikSecurityCloud.Types.MssqlInstance
+            $inst2.Id = 'inst-2'
+            $inst2.Name = 'INSTANCE-2'
+
+            $inst3 = New-Object RubrikSecurityCloud.Types.MssqlInstance
+            $inst3.Id = 'inst-3'
+            $inst3.Name = 'INSTANCE-3'
+
+            # A non-MssqlInstance child to verify the -is [MssqlInstance] filter.
+            # MssqlDatabase implements PhysicalHostDescendantType, so it can sit
+            # in PhysicalHost.descendantConnection.Nodes without a type mismatch.
+            $db = New-Object RubrikSecurityCloud.Types.MssqlDatabase
+            $db.Id = 'db-1'
+            $db.Name = 'DB-1'
+
+            # PhysicalHost — children via descendantConnection.
+            # One MssqlInstance plus one MssqlDatabase (should be filtered).
+            $ph = New-Object RubrikSecurityCloud.Types.PhysicalHost
+            $ph.ObjectType = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::PHYSICAL_HOST
+            $ph.DescendantConnection = New-Object RubrikSecurityCloud.Types.PhysicalHostDescendantTypeConnection
+            $ph.DescendantConnection.Nodes = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.PhysicalHostDescendantType]'
+            $ph.DescendantConnection.Nodes.Add($inst1)
+            $ph.DescendantConnection.Nodes.Add($db)
+
+            # MssqlHost — children via physicalChildConnection.
+            # inst1 is duplicated to exercise dedupe-by-id across parents.
+            $mh = New-Object RubrikSecurityCloud.Types.MssqlHost
+            $mh.ObjectType = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::MSSQL_HOST
+            $mh.PhysicalChildConnection = New-Object RubrikSecurityCloud.Types.MssqlHostPhysicalChildTypeConnection
+            $mh.PhysicalChildConnection.Nodes = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.MssqlHostPhysicalChildType]'
+            $mh.PhysicalChildConnection.Nodes.Add($inst1)
+            $mh.PhysicalChildConnection.Nodes.Add($inst2)
+
+            # WindowsCluster — children via descendantConnection.
+            $wc = New-Object RubrikSecurityCloud.Types.WindowsCluster
+            $wc.ObjectType = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::WINDOWS_CLUSTER
+            $wc.DescendantConnection = New-Object RubrikSecurityCloud.Types.WindowsClusterDescendantTypeConnection
+            $wc.DescendantConnection.Nodes = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.WindowsClusterDescendantType]'
+            $wc.DescendantConnection.Nodes.Add($inst3)
+
+            return [pscustomobject]@{ nodes = @($ph, $mh, $wc) }
+        }
+    }
+
+    It 'returns one row per unique MssqlInstance id (deduped across parents)' {
+        $result = @(Get-RscMssqlInstance -HostName 'test-host')
+        $result.Count | Should -Be 3
+
+        ($result | ForEach-Object { $_.Id } | Sort-Object) |
+            Should -Be @('inst-1', 'inst-2', 'inst-3')
+    }
+
+    It 'filters non-MssqlInstance children out of the result' {
+        $result = @(Get-RscMssqlInstance -HostName 'test-host')
+
+        foreach ($r in $result) {
+            $r | Should -BeOfType [RubrikSecurityCloud.Types.MssqlInstance]
+        }
+        # MssqlDatabase 'db-1' was planted on PhysicalHost.descendantConnection
+        # and must not appear in the result.
+        ($result | Where-Object { $_.Id -eq 'db-1' }).Count | Should -Be 0
+    }
+}
+
+Describe 'Get-RscMssqlInstance -WindowsClusterName response flattening' {
+
+    BeforeAll {
+        Mock Invoke-Rsc -MockWith {
+            $inst = New-Object RubrikSecurityCloud.Types.MssqlInstance
+            $inst.Id = 'wc-inst-1'
+            $inst.Name = 'WC-INSTANCE-1'
+
+            # WindowsCluster — children via descendantConnection (legacy path,
+            # unaffected by HierarchyOverlapFix).
+            $wc = New-Object RubrikSecurityCloud.Types.WindowsCluster
+            $wc.ObjectType = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::WINDOWS_CLUSTER
+            $wc.DescendantConnection = New-Object RubrikSecurityCloud.Types.WindowsClusterDescendantTypeConnection
+            $wc.DescendantConnection.Nodes = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.WindowsClusterDescendantType]'
+            $wc.DescendantConnection.Nodes.Add($inst)
+
+            return [pscustomobject]@{ nodes = @($wc) }
+        }
+    }
+
+    It 'returns the MssqlInstance from a WindowsCluster row' {
+        $result = @(Get-RscMssqlInstance -WindowsClusterName 'test-cluster')
+        $result.Count | Should -Be 1
+        $result[0].Id | Should -Be 'wc-inst-1'
+    }
+}


### PR DESCRIPTION
##Summary:

**Get-RscMssqlInstance** -HostName (and -WindowsClusterName) returned no rows on environments where the backend exposes hosts as the new MssqlHost top-level type. The cmdlet only handled PhysicalHost and WindowsCluster and silently dropped **MssqlHost** rows. This PR adds an **MssqlHost** branch that reads from **physicalChildConnection** (its
  descendantConnection comes back empty), then flattens, type-filters, and dedupes results by id. Also fixes WindowsCluster rows rendering with the wrong format in mixed output by adding it to PhysicalHost.Format.ps1xml's ViewSelectedBy. Adds Pester coverage for the dispatch, filter, and dedupe paths.
 
##Test Plan:
- Added unit tests.
- Manually verified the responses.

##JIRA Issues:
SPARK-869266

##Revert Plan:
None