### PR TITLE
Fix build errors

### DIFF
--- a/Tests/e2e/Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1
+++ b/Tests/e2e/Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1
@@ -23,32 +23,49 @@ Describe -Name 'Query mssqlTopLevelDescendants' -Fixture {
     # MssqlInstance to avoid expanding all 9 implementing types.
 
     It -Name 'PhysicalHost with MssqlInstance children' -Test {
-        # Step 1: Build a PhysicalHost field spec.
-        # "physicalChildConnection.count" walks into the Connection object
-        # and selects its "count" field. This also instantiates
-        # PhysicalChildConnection as a side effect, so we can assign
-        # .Nodes in the next step.
-        $physicalHostFields =
-        Get-RscType -Name PhysicalHost -InitialProperties @(
-            "id",
-            "name",
-            "physicalChildConnection.count"
-        )
+        # Mutate the Autofield-built spec in place — the same pattern
+        # Get-RscMssqlInstance uses (see Toolkit/Public/Get-RscMssqlInstance.ps1
+        # and rubrik-powershell-sdk PR #253). Passing -Field to override
+        # the spec does NOT work reliably: the SDK still runs Autofield
+        # DEFAULT on top of any -Field input, re-pulling fields the test
+        # didn't ask for.
+        $query = New-RscQuery -Gql mssqlTopLevelDescendants
 
-        # Step 2: PhysicalChildConnection.Nodes is a List<Interface>.
-        # Manually set it to MssqlInstance to avoid expanding all
-        # implementing types (ExchangeServer, FilesetTemplate, etc.).
-        $physicalHostFields.PhysicalChildConnection.Nodes =
-        Get-RscType -Name MssqlInstance -InitialProperties ("Id", "Name")
+        # Reduce the top-level nodes list to PhysicalHost only. This
+        # eliminates the GraphQL field-merging conflict between
+        # MssqlDatabase (hasPermissions: Boolean!, version: String) and
+        # MssqlInstance (hasPermissions: Boolean, version: String!) that
+        # Autofield's DEFAULT profile triggers when both implementers
+        # appear as sibling inline fragments under the same nodes selection.
+        # (Schema split on 2026-04-20, commit 375007994861.)
+        #
+        # Mutate the underlying List<T> directly with RemoveAt — Clear()
+        # + Add() with a pipeline-retrieved $physicalHost silently
+        # no-ops, likely because the pipeline returns a PSObject wrapper
+        # the typed list rejects.
+        for ($i = $query.Field.Nodes.Count - 1; $i -ge 0; $i--) {
+            if ($query.Field.Nodes[$i].GetType().Name -ne "PhysicalHost") {
+                $query.Field.Nodes.RemoveAt($i)
+            }
+        }
+        $physicalHost = $query.Field.Nodes[0]
 
-        # Step 3: Build the top-level Connection and assign .nodes to
-        # our PhysicalHost (instead of letting Get-RscType expand all
-        # 6 implementing types of MssqlTopLevelDescendantType).
-        $fields = Get-RscType -Name MssqlTopLevelDescendantTypeConnection
-        $fields.nodes = $physicalHostFields
+        # Replace PhysicalHost.physicalChildConnection (which Autofield
+        # filled with all 9 implementers of PhysicalHostPhysicalChildType)
+        # with a fresh connection holding only MssqlInstance — this
+        # exercises the manual List<Interface> construction the test was
+        # written to validate.
+        $physicalHost.PhysicalChildConnection = New-Object `
+            -TypeName RubrikSecurityCloud.Types.PhysicalHostPhysicalChildTypeConnection
+        $physicalHost.PhysicalChildConnection.Count = [Int32]::MinValue
+        $physicalHost.PhysicalChildConnection.Nodes = New-Object `
+            -TypeName RubrikSecurityCloud.Types.MssqlInstance
+        $childIndex = $physicalHost.PhysicalChildConnection.Nodes.FindIndex(
+            {param($n) $n.GetType().Name -eq "MssqlInstance"})
+        $physicalHost.PhysicalChildConnection.Nodes[$childIndex].Id = "FETCH"
+        $physicalHost.PhysicalChildConnection.Nodes[$childIndex].Name = "FETCH"
 
-        # Step 4: Query using the hand-crafted field spec.
-        $sqlObjects = (New-RscQuery -Gql mssqlTopLevelDescendants -Field $fields).Invoke()
+        $sqlObjects = $query.Invoke()
         $sqlObjects.nodes | Should -Not -BeNullOrEmpty
     }
 }

--- a/Tests/unit/Patching.Tests.ps1
+++ b/Tests/unit/Patching.Tests.ps1
@@ -34,7 +34,7 @@ Describe -Name "Test patching" -Fixture {
 
         # The following hard-coded list needs to be updated manually
         # when the schema changes. The repetition is intentional.
-        $defaultNodes = "pauseStatus status statusFromDb subStatus systemStatus type id isAirGapped isClusterRemovalTprEnabled isHealthy name systemStatusMessage version"
+        $defaultNodes = "pauseStatus status statusFromDb subStatus systemStatus type id isAirGapped isAssignedByParentAccount isClusterRemovalTprEnabled isHealthy name systemStatusMessage version"
 
         $defaultNodesSnapshot = $defaultNodes -replace 'name', 'name snapshotcount'
         $pageInfo = "pageInfo { endCursor hasNextPage hasPreviousPage startCursor }"
@@ -105,7 +105,7 @@ Describe -Name "Test patching" -Fixture {
 
         # The following hard-coded list needs to be updated manually
         # when the schema changes. The repetition is intentional.
-        $defaultWithSnapshotAndEstimatedRunway = "pauseStatus status statusFromDb subStatus systemStatus type estimatedRunway id isAirGapped isClusterRemovalTprEnabled isHealthy name snapshotCount systemStatusMessage version"
+        $defaultWithSnapshotAndEstimatedRunway = "pauseStatus status statusFromDb subStatus systemStatus type estimatedRunway id isAirGapped isAssignedByParentAccount isClusterRemovalTprEnabled isHealthy name snapshotCount systemStatusMessage version"
 
         $qc2ExpectedFs = "count nodes { $defaultWithSnapshotAndEstimatedRunway } $pageInfo"
         $qc2Fs | Should -Be $qc2ExpectedFs
@@ -160,7 +160,7 @@ Describe -Name "Test patching" -Fixture {
 
         # The following hard-coded list needs to be updated manually
         # when the schema changes. The repetition is intentional.
-        $defaultNodesEstimatedRunway = "pauseStatus status statusFromDb subStatus systemStatus type estimatedRunway id isAirGapped isClusterRemovalTprEnabled isHealthy name systemStatusMessage version"
+        $defaultNodesEstimatedRunway = "pauseStatus status statusFromDb subStatus systemStatus type estimatedRunway id isAirGapped isAssignedByParentAccount isClusterRemovalTprEnabled isHealthy name systemStatusMessage version"
 
         $qf3ExpectedFs = "count nodes { $defaultNodesEstimatedRunway } $pageInfo"
         $qf3Fs | Should -Be $qf3ExpectedFs

--- a/Toolkit/Public/Get-RscMssqlInstance.ps1
+++ b/Toolkit/Public/Get-RscMssqlInstance.ps1
@@ -242,6 +242,30 @@ Return the query object instead of executing it.
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes[$mssqlInstanceIndex].name = "FETCH"
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes[$mssqlInstanceIndex].id = "FETCH"
 
+            # TODO: SPARK-900409
+            # mssqlTopLevelDescendants expands all MssqlTopLevelDescendantType
+            # implementers. MssqlDatabase (version: String, hasPermissions:
+            # Boolean!) and MssqlInstance (version: String!, hasPermissions:
+            # Boolean) declare these scalars with conflicting nullability.
+            # MssqlInstance's version/hasPermissions were added in a recent
+            # schema update, so we exclude them on MssqlInstance (not
+            # MssqlDatabase) to preserve backward compatibility while clearing
+            # the conflict. Nulling doesn't stick (GqlRequest re-explores and
+            # re-adds the non-null version), so copy the node's fields into a
+            # fresh, non-explored MssqlInstance, skipping Version and
+            # HasPermissions.
+            $topMssqlInstanceIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlInstance"})
+            if ($topMssqlInstanceIndex -ge 0) {
+                $src = $query.field.Nodes[$topMssqlInstanceIndex]
+                $trimmed = New-Object -TypeName RubrikSecurityCloud.Types.MssqlInstance
+                foreach ($prop in $src.PSObject.Properties) {
+                    if ($null -ne $prop.Value -and $prop.Name -ne "Version" -and $prop.Name -ne "HasPermissions") {
+                        try { $trimmed.($prop.Name) = $prop.Value } catch {}
+                    }
+                }
+                $query.field.Nodes[$topMssqlInstanceIndex] = $trimmed
+            }
+
             if ( $AsQuery ) {
                 return $query
             }

--- a/Toolkit/Tests/unit/Baselines/Get-RscMssqlInstance.ps1
+++ b/Toolkit/Tests/unit/Baselines/Get-RscMssqlInstance.ps1
@@ -242,6 +242,30 @@ Return the query object instead of executing it.
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes[$mssqlInstanceIndex].name = "FETCH"
             $query.field.Nodes[$windowsClusterIndex].descendantConnection.nodes[$mssqlInstanceIndex].id = "FETCH"
 
+            # mssqlTopLevelDescendants expands all MssqlTopLevelDescendantType
+            # implementers. MssqlDatabase (version: String, hasPermissions:
+            # Boolean!) and MssqlInstance (version: String!, hasPermissions:
+            # Boolean) declare these scalars with conflicting nullability.
+            # MssqlInstance's version/hasPermissions were added in a recent
+            # schema update, so we exclude them on MssqlInstance (not
+            # MssqlDatabase) to preserve backward compatibility while clearing
+            # the conflict. Nulling doesn't stick (GqlRequest re-explores and
+            # re-adds the non-null version), so copy the node's fields into a
+            # fresh, non-explored MssqlInstance, skipping Version and
+            # HasPermissions. Synced with the Toolkit/Public version for the
+            # equivalence test.
+            $topMssqlInstanceIndex = $query.field.nodes.FindIndex({param($item) $item.gettype().name -eq "MssqlInstance"})
+            if ($topMssqlInstanceIndex -ge 0) {
+                $src = $query.field.Nodes[$topMssqlInstanceIndex]
+                $trimmed = New-Object -TypeName RubrikSecurityCloud.Types.MssqlInstance
+                foreach ($prop in $src.PSObject.Properties) {
+                    if ($null -ne $prop.Value -and $prop.Name -ne "Version" -and $prop.Name -ne "HasPermissions") {
+                        try { $trimmed.($prop.Name) = $prop.Value } catch {}
+                    }
+                }
+                $query.field.Nodes[$topMssqlInstanceIndex] = $trimmed
+            }
+
             if ( $AsQuery ) {
                 return $query
             }


### PR DESCRIPTION
## Summary:

  Fixes build failures in the PowerShell SDK caused by a GraphQL field-merging conflict in mssqlTopLevelDescendants. MssqlInstance recently gained version and hasPermissions fields whose nullability diverges from the same fields on MssqlDatabase.
  Because both types are merged under the same selection set, the schema explorer produces conflicting field definitions and the build/query fails.

  This change works around the conflict by trimming Version and HasPermissions off the top-level MssqlInstance node before the query is invoked:

  - Toolkit/Public/Get-RscMssqlInstance.ps1 — after the FETCH placeholder is set, locate the top-level MssqlInstance node and copy its properties into a fresh instance, skipping Version and HasPermissions. (Simply nulling the fields didn't stick — the
  request re-explores them.)
  - Toolkit/Tests/unit/Baselines/Get-RscMssqlInstance.ps1 — same block, kept in sync for the baseline equivalence test.
  - Tests/e2e/Invoke-RscQueryMssql-TopLevelDescendant.Tests.ps1 — rewritten to build the query and mutate it in place (drop non-PhysicalHost nodes, swap in an MssqlInstance-only PhysicalChildConnection) instead of passing a hand-crafted -Field spec.
  - Tests/unit/Patching.Tests.ps1 — updated three hard-coded expected field lists to include the new schema field isAssignedByParentAccount.

## Test Plan:

  - make build succeeds.
  - Unit and e2e MSSQL top-level-descendant is updated.
  - Manually run the `Get-RscMssqlInstance` cmdlet and verified that, it is working as expected.

## JIRA Issues:
SPARK-868151

## Revert Plan:
None