### PR TITLE
Rename New-RscMssqlExport params with backward-compatible aliases

### DIFF
--- a/Toolkit/Public/New-RscMssqlExport.ps1
+++ b/Toolkit/Public/New-RscMssqlExport.ps1
@@ -17,8 +17,9 @@ function New-RscMssqlExport{
     .PARAMETER RecoveryDateTime
     The point-in-time to recover to, in UTC. Use Get-RscMssqlDatabaseRecoveryPoint to obtain a properly formatted value.
 
-    .PARAMETER TargetMssqlInstance
+    .PARAMETER TargetInstance
     The destination SQL Server instance. Pipe from Get-RscMssqlInstance.
+    Alias: TargetMssqlInstance (retained for backward compatibility).
 
     .PARAMETER TargetDatabaseName
     The name for the exported database on the target instance.
@@ -26,8 +27,9 @@ function New-RscMssqlExport{
     .PARAMETER TargetDataPath
     A single directory path where all data files will be placed (simple mode).
 
-    .PARAMETER TargeLogPath
+    .PARAMETER TargetLogPath
     A single directory path where all log files will be placed (simple mode).
+    Alias: TargeLogPath (retained for backward compatibility).
 
     .PARAMETER TargetFilePaths
     An array of objects specifying per-file exportPath, logicalName, and newFilename (advanced mode). Build manually or use Get-RscMssqlDatabaseFiles. The logicalName must match the original database; exportPath and newFilename can be customized.
@@ -53,10 +55,10 @@ function New-RscMssqlExport{
     $inst = Get-RscMssqlInstance -HostName rp-sql1.rubrik-demo.com -clusterId "124d26df-c31f-49a3-a8c3-77b10c9470c2"
     New-RscMssqlExport -RscMssqlDatabase $db `
         -RecoveryDateTime "2024-03-05T19:17:30.000Z" `
-        -TargetMssqlInstance $inst `
+        -TargetInstance $inst `
         -TargetDatabaseName "AW2019_Copy" `
         -TargetDataPath "c:\mnt\sqldata" `
-        -TargeLogPath "c:\mnt\sqllogs" `
+        -TargetLogPath "c:\mnt\sqllogs" `
         -Overwrite -FinishRecovery
 
     .EXAMPLE
@@ -70,7 +72,7 @@ function New-RscMssqlExport{
     )
     New-RscMssqlExport -RscMssqlDatabase $db `
         -RecoveryDateTime "2024-03-05T19:17:30.000Z" `
-        -TargetMssqlInstance $inst `
+        -TargetInstance $inst `
         -TargetDatabaseName "AW2019_Copy" `
         -TargetFilePaths $filePaths `
         -Overwrite -FinishRecovery
@@ -93,7 +95,9 @@ function New-RscMssqlExport{
 
         [Parameter(
             Mandatory = $true
-        )][RubrikSecurityCloud.Types.MssqlInstance]$TargetMssqlInstance, 
+        )]
+        [Alias("TargetMssqlInstance")]
+        [RubrikSecurityCloud.Types.MssqlInstance]$TargetInstance,
 
         [Parameter(
             Mandatory = $true
@@ -107,7 +111,9 @@ function New-RscMssqlExport{
         [Parameter(
             ParameterSetName = "Simple Method",
             Mandatory = $false
-        )][String]$TargeLogPath,
+        )]
+        [Alias("TargeLogPath")]
+        [String]$TargetLogPath,
 
         [Parameter(
             ParameterSetName = "Advanced Method",
@@ -155,9 +161,9 @@ function New-RscMssqlExport{
         # $query.Var.input.Config.recoveryPoint.lsnPoint = New-Object -TypeName RubrikSecurityCloud.Types.LsnRecoveryPointInput 
 
         # Simple Method
-        If (![string]::IsNullOrEmpty($TargetDataPath) -and ![string]::IsNullOrEmpty($TargeLogPath)){
+        If (![string]::IsNullOrEmpty($TargetDataPath) -and ![string]::IsNullOrEmpty($TargetLogPath)){
                 $query.Var.input.Config.targetDataFilePath = $TargetDataPath
-                $query.Var.input.Config.targetLogFilePath = $TargeLogPath
+                $query.Var.input.Config.targetLogFilePath = $TargetLogPath
         }
 
         # Advanced Method
@@ -166,7 +172,7 @@ function New-RscMssqlExport{
             $query.Var.input.Config.targetFilePaths = $TargetFilePaths
         }
     
-        $query.Var.input.Config.targetInstanceId = $TargetMssqlInstance.Id
+        $query.Var.input.Config.targetInstanceId = $TargetInstance.Id
         #endregion
 
         if ( $AsQuery ) { return $query }

--- a/Toolkit/Tests/unit/AsQuery.Tests.ps1
+++ b/Toolkit/Tests/unit/AsQuery.Tests.ps1
@@ -42,7 +42,7 @@ Describe -Name "AsQuery Parameter Tests" -Fixture {
             'Get-RscMssqlDatabaseRecoverableRanges'  = @{ RscMssqlDatabase = $mockMssqlDb }
             'Get-RscMssqlDatabaseRecoveryPoint'      = @{ RscMssqlDatabase = $mockMssqlDb; Latest = $true }
             'Get-RscSnapshot'                        = @{ Id = '00000000-0000-0000-0000-000000000000' }
-            'New-RscMssqlExport'                     = @{ RscMssqlDatabase = $mockMssqlDb; RecoveryDateTime = [datetime]'2024-01-01'; TargetMssqlInstance = $mockMssqlInstance; TargetDatabaseName = 'mock'; TargetDataPath = 'c:\data'; TargeLogPath = 'c:\log' }
+            'New-RscMssqlExport'                     = @{ RscMssqlDatabase = $mockMssqlDb; RecoveryDateTime = [datetime]'2024-01-01'; TargetInstance = $mockMssqlInstance; TargetDatabaseName = 'mock'; TargetDataPath = 'c:\data'; TargetLogPath = 'c:\log' }
             'New-RscMssqlLiveMount'                  = @{ RscMssqlDatabase = $mockMssqlDb; MountedDatabaseName = 'mock'; TargetMssqlInstance = $mockMssqlInstance; RecoveryDateTime = [datetime]'2024-01-01' }
             'New-RscMssqlLogBackup'                  = @{ RscMssqlDatabase = $mockMssqlDb }
             'New-RscMssqlLogShippingSecondary'       = @{ RscMssqlDatabase = $mockMssqlDb; TargetMssqlInstance = $mockMssqlInstance; TargetDatabaseName = 'mock'; State = 'RESTORING'; TargetDataPath = 'c:\data'; TargeLogPath = 'c:\log' }
@@ -108,5 +108,18 @@ Describe -Name "AsQuery Parameter Tests" -Fixture {
             $msg = "$($failures.Count) command(s) failed:`n" + ($failures -join "`n")
             $msg | Should -BeNullOrEmpty
         }
+    }
+}
+
+Describe -Name "New-RscMssqlExport parameter aliases" -Fixture {
+
+    # Verify backward-compatible aliases are retained after the
+    # TargeLogPath -> TargetLogPath and TargetMssqlInstance -> TargetInstance
+    # renames, so existing scripts using the old names keep working.
+    It -Name '<Old> is an alias for <New>' -ForEach @(
+        @{ Old = 'TargetMssqlInstance'; New = 'TargetInstance' }
+        @{ Old = 'TargeLogPath';        New = 'TargetLogPath'  }
+    ) -Test {
+        (Get-Command New-RscMssqlExport).Parameters[$New].Aliases | Should -Contain $Old
     }
 }


### PR DESCRIPTION
## Summary:
Cleans up two parameter names on New-RscMssqlExport, keeping the old names as aliases so existing scripts continue to work unchanged.
- Fix typo: -TargeLogPath → -TargetLogPath (old name kept as alias TargeLogPath)
- Rename for clarity: -TargetMssqlInstance → -TargetInstance (old name kept as alias TargetMssqlInstance)
Both old names are preserved via [Alias()], so callers using -TargeLogPath / -TargetMssqlInstance keep working.

## Test Plan:
  - Added a new alias unit test. 
  - Manually verify the changes.
    (Get-Command New-RscMssqlExport).Parameters['TargetInstance'].Aliases   # -> TargetMssqlInstance
    (Get-Command New-RscMssqlExport).Parameters['TargetLogPath'].Aliases    # -> TargeLogPath
  
## JIRA Issues:
SPARK-886455

## Revert Plan:
None