### PR TITLE
Fix Get-RscWorkload failure from ClusterSlaDomain V2 migration

### DIFF
--- a/Toolkit/Public/Get-RscWorkload.ps1
+++ b/Toolkit/Public/Get-RscWorkload.ps1
@@ -135,7 +135,7 @@ function Get-RscWorkload {
         $query.Field.Nodes[0].ncdLatestArchiveSnapshot = [System.Datetime]"1/1/2000"
         $query.Field.Nodes[0].slaDomain = New-Object RubrikSecurityCloud.Types.GlobalSlaReply
         $query.Field.Nodes[0].slaDomain.name = "FOO"
-        $query.Field.Nodes[0].slaDomain.id = "FOO"
+        $query.Field.Nodes[0].slaDomain.fid = "FOO"
         $query.Field.Nodes[0].cluster = New-Object RubrikSecurityCloud.Types.Cluster
         $query.Field.Nodes[0].cluster.name = "FOO"
         $query.Field.Nodes[0].cluster.id = "FOO"


### PR DESCRIPTION
## Summary
- Works around a server-side regression introduced by [sdmain#208950](https://github.com/scaledata/sdmain/pull/208950) (Migrate ClusterSlaDomainType and GlobalSlaType to V2Types)
- The V2 migration renamed `ProtoClusterSlaDomain.id` to `cdmId`, breaking `id` field resolution on placeholder SLA domains in `snappableConnection`
- Replaces `slaDomain.id` with `slaDomain.fid` in the `Get-RscWorkload` field selection to avoid the broken resolver path

## Root Cause
PR sdmain#208950 made three changes that combined to break `snappableConnection` queries:
1. **Proto field rename**: `ProtoClusterSlaDomain.id` → `cdmId`
2. **Type definition switch**: `ClusterSlaDomainType` moved from manual Sangria `deriveObjectType` (with explicit `id` resolver) to `V2Types.objectType(ProtoClusterSlaDomain)` (auto-generated, no `id` field on proto)
3. **Placeholder construction**: `SnappableTypes.scala` creates a placeholder SLA domain where `id` is set on the outer `ProtoSlaDomain` wrapper but not propagated to the inner `ProtoClusterSlaDomain` — V2Types can't resolve `id` → null for `String!` → API error

## Test plan
- [ ] `Workload.Tests.ps1` e2e test `lists VMware workloads` should pass
- [ ] Other `Get-RscWorkload` tests (by RSC ID, CDM ID, compliance status) should pass
- [ ] SLA domain `fid` is returned correctly on workload results

🤖 Generated with [Claude Code](https://claude.com/claude-code)