### PR TITLE
Auto release

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,13 @@ with `Disconnect-Rsc`. Note however that it is not strictly
 necessary, as the connection will be closed automatically
 when the session ends.
 
+## Contributing
+
+Before opening a pull request, please read the
+[PR requirements](Utils/admin/HOWTO_AUTO_RELEASE.md#pr-requirements) —
+every PR that introduces a user-facing change must update `CHANGELOG.md`
+with the PR number and a short description.
+
 ## Learning more about this SDK
 
 :point_right: Start with the

--- a/RubrikSecurityCloud/VERSION.md
+++ b/RubrikSecurityCloud/VERSION.md
@@ -1,0 +1,16 @@
+# PowerShell SDK Versioning
+
+The PowerShell SDK uses the versioning format `<Major>.<Minor>.<Schema>`:
+
+- **Major Version**: Incremented when core SDK changes are made.
+- **Minor Version**: Incremented for bug fixes or when cmdlets in the Toolkit are added or modified.
+- **Schema Version**: Reflects the version of the GraphQL schema used to build the SDK.
+
+# Current Version
+
+This reflects the in-progress state of the SDK on GitHub, not the last published release.
+It drives the automated release process. Only the major version should be changed manually; when doing so, reset the minor version to 0.
+
+### Major Version: 1
+### Minor Version: 18
+### Schema Version: 20260601

--- a/Utils/admin/Get-NextReleaseVersionNumber.Tests.ps1
+++ b/Utils/admin/Get-NextReleaseVersionNumber.Tests.ps1
@@ -1,0 +1,142 @@
+Describe 'Get-NextReleaseVersionNumber' {
+
+    BeforeAll {
+        $script:scriptPath = "$PSScriptRoot\Get-NextReleaseVersionNumber.ps1"
+
+        function New-TempVersionMd($major, $minor) {
+            $path = [System.IO.Path]::GetTempFileName()
+            @"
+# Current Version
+
+### Major Version: $major
+### Minor Version: $minor
+### Schema Version: 99999999
+"@ | Set-Content -Path $path
+            return $path
+        }
+
+        function New-TempChangelog($features, $fixes, $breaking, $lastMajor) {
+            $path = [System.IO.Path]::GetTempFileName()
+            @"
+# Changelog
+
+## Version TBD
+
+New Features:
+$features
+Fixes:
+$fixes
+Breaking Changes:
+$breaking
+## Version ${lastMajor}.5.20260101
+
+New Features:
+- Initial release
+"@ | Set-Content -Path $path
+            return $path
+        }
+
+        function New-TempPsd1($schemaDate) {
+            $path = [System.IO.Path]::GetTempFileName() + ".psd1"
+            @"
+@{
+    Description = 'PowerShell Module for Rubrik Security Cloud. GraphQL schema version: v${schemaDate}-1 .'
+}
+"@ | Set-Content -Path $path
+            return $path
+        }
+    }
+
+    Context 'Schema version' {
+        It 'reads schema date from psd1 Description' {
+            $vf = New-TempVersionMd 1 5
+            $cf = New-TempChangelog '' '' '' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Schema | Should -Be 20260601
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Minor version — no changelog entries' {
+        It 'keeps Minor unchanged when TBD sections are empty' {
+            $vf = New-TempVersionMd 1 18
+            $cf = New-TempChangelog '' '' '' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Minor | Should -Be 18
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'keeps Minor unchanged when all TBD sections contain only "None"' {
+            $vf = New-TempVersionMd 1 18
+            $cf = New-TempChangelog 'None' 'None' 'None' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Minor | Should -Be 18
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Minor version — changelog has entries' {
+        It 'increments Minor by 1 when New Features has an entry' {
+            $vf = New-TempVersionMd 1 18
+            $cf = New-TempChangelog '- New cmdlet added' '' '' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Minor | Should -Be 19
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'increments Minor by 1 when Fixes has an entry' {
+            $vf = New-TempVersionMd 1 18
+            $cf = New-TempChangelog '' '- Fixed a bug' '' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Minor | Should -Be 19
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'increments Minor by 1 when Breaking Changes has an entry' {
+            $vf = New-TempVersionMd 1 18
+            $cf = New-TempChangelog '' '' '- Removed old parameter' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Minor | Should -Be 19
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Major version bump' {
+        It 'resets Minor to 0 when Major in VERSION.md is greater than last released Major' {
+            $vf = New-TempVersionMd 2 18
+            $cf = New-TempChangelog '- New feature' '' '' 1
+            $pf = New-TempPsd1 '20260601'
+            try {
+                $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
+                $result.Major | Should -Be 2
+                $result.Minor | Should -Be 0
+            } finally {
+                Remove-Item $vf, $cf, $pf -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/Utils/admin/Get-NextReleaseVersionNumber.Tests.ps1
+++ b/Utils/admin/Get-NextReleaseVersionNumber.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Get-NextReleaseVersionNumber' {
             return $path
         }
 
-        function New-TempChangelog($features, $fixes, $breaking, $lastMajor) {
+        function New-TempChangelog($features, $fixes, $breaking, $lastMajor, $lastMinor = 5) {
             $path = [System.IO.Path]::GetTempFileName()
             @"
 # Changelog
@@ -28,7 +28,7 @@ Fixes:
 $fixes
 Breaking Changes:
 $breaking
-## Version ${lastMajor}.5.20260101
+## Version ${lastMajor}.${lastMinor}.20260101
 
 New Features:
 - Initial release
@@ -50,7 +50,7 @@ New Features:
     Context 'Schema version' {
         It 'reads schema date from psd1 Description' {
             $vf = New-TempVersionMd 1 5
-            $cf = New-TempChangelog '' '' '' 1
+            $cf = New-TempChangelog '' '' '' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
@@ -64,7 +64,7 @@ New Features:
     Context 'Minor version — no changelog entries' {
         It 'keeps Minor unchanged when TBD sections are empty' {
             $vf = New-TempVersionMd 1 18
-            $cf = New-TempChangelog '' '' '' 1
+            $cf = New-TempChangelog '' '' '' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
@@ -76,7 +76,7 @@ New Features:
 
         It 'keeps Minor unchanged when all TBD sections contain only "None"' {
             $vf = New-TempVersionMd 1 18
-            $cf = New-TempChangelog 'None' 'None' 'None' 1
+            $cf = New-TempChangelog 'None' 'None' 'None' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
@@ -90,7 +90,7 @@ New Features:
     Context 'Minor version — changelog has entries' {
         It 'increments Minor by 1 when New Features has an entry' {
             $vf = New-TempVersionMd 1 18
-            $cf = New-TempChangelog '- New cmdlet added' '' '' 1
+            $cf = New-TempChangelog '- New cmdlet added' '' '' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
@@ -102,7 +102,7 @@ New Features:
 
         It 'increments Minor by 1 when Fixes has an entry' {
             $vf = New-TempVersionMd 1 18
-            $cf = New-TempChangelog '' '- Fixed a bug' '' 1
+            $cf = New-TempChangelog '' '- Fixed a bug' '' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
@@ -114,7 +114,7 @@ New Features:
 
         It 'increments Minor by 1 when Breaking Changes has an entry' {
             $vf = New-TempVersionMd 1 18
-            $cf = New-TempChangelog '' '' '- Removed old parameter' 1
+            $cf = New-TempChangelog '' '' '- Removed old parameter' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf
@@ -128,7 +128,7 @@ New Features:
     Context 'Major version bump' {
         It 'resets Minor to 0 when Major in VERSION.md is greater than last released Major' {
             $vf = New-TempVersionMd 2 18
-            $cf = New-TempChangelog '- New feature' '' '' 1
+            $cf = New-TempChangelog '- New feature' '' '' 1 18
             $pf = New-TempPsd1 '20260601'
             try {
                 $result = & $script:scriptPath -VersionFile $vf -ChangelogFile $cf -Psd1File $pf

--- a/Utils/admin/Get-NextReleaseVersionNumber.ps1
+++ b/Utils/admin/Get-NextReleaseVersionNumber.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$VersionFile   = (Join-Path $PSScriptRoot "..\..\RubrikSecurityCloud\VERSION.md"),
+    [string]$VersionFile   = (Join-Path $PSScriptRoot "..\..\VERSION.md"),
     [string]$ChangelogFile = (Join-Path $PSScriptRoot "..\..\CHANGELOG.md"),
     [string]$Psd1File      = (Join-Path $PSScriptRoot "..\..\RubrikSecurityCloud\RubrikSecurityCloud.PowerShell\RubrikSecurityCloud.psd1")
 )

--- a/Utils/admin/Get-NextReleaseVersionNumber.ps1
+++ b/Utils/admin/Get-NextReleaseVersionNumber.ps1
@@ -43,6 +43,19 @@ function GetLastReleasedMajor($changelogFile) {
     return [int]$Matches[1]
 }
 
+# Returns the Minor version number from the last released entry in CHANGELOG.md
+# (i.e. the first "## Version X.Y.Z" line that is not TBD).
+function GetLastReleasedMinor($changelogFile) {
+    $line = Get-Content $changelogFile |
+        Where-Object { $_ -match '^## Version \d+\.(\d+)\.\d+' } |
+        Select-Object -First 1
+    if (-not $line) {
+        throw "Could not find a released version entry in $changelogFile"
+    }
+    $null = $line -match '^## Version \d+\.(\d+)'
+    return [int]$Matches[1]
+}
+
 # Check whether the "## Version TBD" block in CHANGELOG.md has any real entries
 # (non-empty, non-"None") under New Features, Fixes, or Breaking Changes.
 function HasChangelogEntries($changelogFile) {
@@ -74,9 +87,9 @@ function HasChangelogEntries($changelogFile) {
 
 $versionLines      = Get-Content $versionFile
 $major             = ParseVersionField $versionLines "Major Version"
-$minor             = ParseVersionField $versionLines "Minor Version"
 $schema            = GetSchemaVersionFromPsd1 $psd1File
 $lastReleasedMajor = GetLastReleasedMajor $changelogFile
+$minor             = GetLastReleasedMinor $changelogFile
 
 if ($major -gt $lastReleasedMajor) {
     # Major version bumped — reset Minor to 0

--- a/Utils/admin/Get-NextReleaseVersionNumber.ps1
+++ b/Utils/admin/Get-NextReleaseVersionNumber.ps1
@@ -1,0 +1,92 @@
+param(
+    [string]$VersionFile   = (Join-Path $PSScriptRoot "..\..\RubrikSecurityCloud\VERSION.md"),
+    [string]$ChangelogFile = (Join-Path $PSScriptRoot "..\..\CHANGELOG.md"),
+    [string]$Psd1File      = (Join-Path $PSScriptRoot "..\..\RubrikSecurityCloud\RubrikSecurityCloud.PowerShell\RubrikSecurityCloud.psd1")
+)
+$ErrorActionPreference = "Stop"
+
+$versionFile   = $VersionFile
+$changelogFile = $ChangelogFile
+$psd1File      = $Psd1File
+
+# Read a numeric field from VERSION.md (e.g. "### Minor Version: 18")
+function ParseVersionField($lines, $label) {
+    $line = $lines | Where-Object { $_ -match "###\s+$label\s*:\s*(\d+)" } | Select-Object -First 1
+    if (-not $line) {
+        throw "Could not find '$label' in $versionFile"
+    }
+    $null = $line -match '(\d+)\s*$'
+    return [int]$Matches[1]
+}
+
+# Reads the schema date (YYYYMMDD) from the Description field in the .psd1.
+# Jenkins updates the description to e.g. "... GraphQL schema version: v20260601-47 ."
+function GetSchemaVersionFromPsd1($psd1File) {
+    $moduleInfo = Import-PowerShellDataFile $psd1File
+    $desc = $moduleInfo.Description
+    if ($desc -notmatch 'GraphQL schema version:\s*v?(\d{8})') {
+        throw "Could not extract schema version from Description in $psd1File"
+    }
+    return [int]$Matches[1]
+}
+
+# Returns the Major version number from the last released entry in CHANGELOG.md
+# (i.e. the first "## Version X.Y.Z" line that is not TBD).
+function GetLastReleasedMajor($changelogFile) {
+    $line = Get-Content $changelogFile |
+        Where-Object { $_ -match '^## Version (\d+)\.\d+\.\d+' } |
+        Select-Object -First 1
+    if (-not $line) {
+        throw "Could not find a released version entry in $changelogFile"
+    }
+    $null = $line -match '^## Version (\d+)'
+    return [int]$Matches[1]
+}
+
+# Check whether the "## Version TBD" block in CHANGELOG.md has any real entries
+# (non-empty, non-"None") under New Features, Fixes, or Breaking Changes.
+function HasChangelogEntries($changelogFile) {
+    $content = Get-Content $changelogFile -Raw
+    $content = $content -replace "`r`n", "`n"
+
+    # Extract only the TBD block (everything up to the next ## Version heading)
+    $match = [regex]::Match($content, '## Version TBD\n(.+?)(?=\n## Version |\z)', 'Singleline')
+    if (-not $match.Success) {
+        return $false
+    }
+    $tdBlock = $match.Groups[1].Value
+
+    foreach ($section in @('New Features', 'Fixes', 'Breaking Changes')) {
+        $secMatch = [regex]::Match(
+            $tdBlock,
+            "${section}:\n(.*?)(?=\n[A-Z][^:]+:|\z)",
+            'Singleline'
+        )
+        if (-not $secMatch.Success) { continue }
+
+        $body = $secMatch.Groups[1].Value.Trim()
+        if ($body -and $body -notmatch '^\s*None\s*$') {
+            return $true
+        }
+    }
+    return $false
+}
+
+$versionLines      = Get-Content $versionFile
+$major             = ParseVersionField $versionLines "Major Version"
+$minor             = ParseVersionField $versionLines "Minor Version"
+$schema            = GetSchemaVersionFromPsd1 $psd1File
+$lastReleasedMajor = GetLastReleasedMajor $changelogFile
+
+if ($major -gt $lastReleasedMajor) {
+    # Major version bumped — reset Minor to 0
+    $minor = 0
+} elseif (HasChangelogEntries $changelogFile) {
+    $minor++
+}
+
+return [PSCustomObject]@{
+    Major  = $major
+    Minor  = $minor
+    Schema = $schema
+}

--- a/Utils/admin/HOWTO_AUTO_RELEASE.md
+++ b/Utils/admin/HOWTO_AUTO_RELEASE.md
@@ -60,7 +60,7 @@ Same as the manual release:
 
 | Component | Source |
 |-----------|--------|
-| **Major** | `### Major Version` field in `RubrikSecurityCloud/VERSION.md` |
+| **Major** | `### Major Version` field in `VERSION.md` |
 | **Minor** | `### Minor Version` field in `VERSION.md`, then adjusted (see rules below) |
 | **Schema** | Extracted from the `Description` field in `RubrikSecurityCloud.psd1` — updated automatically by the Jenkins schema pipeline |
 

--- a/Utils/admin/HOWTO_AUTO_RELEASE.md
+++ b/Utils/admin/HOWTO_AUTO_RELEASE.md
@@ -1,0 +1,119 @@
+# Automated SDK Release
+
+`Invoke-RscSdkAutoRelease.ps1` automates the full release pipeline without
+requiring manual version entry. It follows the same steps as
+`HOWTO_MAKE_A_RELEASE.md` but computes the version automatically from the
+repository state.
+
+## PR requirements
+
+Every pull request that introduces a user-facing change **must** update
+`CHANGELOG.md` before it can be merged. Schema-only PRs (automatic schema
+updates from the Jenkins pipeline) are exempt.
+
+### What to add
+
+Under the `## Version TBD` block, add a line to the appropriate section:
+
+```markdown
+## Version TBD
+
+New Features:
+- Brief description of the new feature or cmdlet (#<PR number>)
+
+Fixes:
+- Brief description of what was fixed (#<PR number>)
+
+Breaking Changes:
+- Brief description of what changed and how to migrate (#<PR number>)
+```
+
+### Rules
+
+- Each entry must include the PR number as `(#NNN)` at the end.
+- Write for SDK users, not internal reviewers — describe the visible behavior change.
+- A single PR may add entries to more than one section if applicable.
+- If a section has no changes, leave it empty or write `None` — do not omit the heading.
+- Schema-only PRs (no new features, fixes, or breaking changes) do not need a changelog entry.
+
+### Why this matters
+
+The automated release pipeline (`Invoke-RscSdkAutoRelease.ps1`) determines
+whether to increment the minor version by checking whether the `## Version TBD`
+block has any real entries. A PR that skips the changelog update will not
+trigger a minor version bump, and its changes may be grouped into a future
+release under a different version than expected.
+
+## Prerequisites
+
+Same as the manual release:
+
+- On the `devel` branch with a clean working tree (`git status`).
+- `gh` CLI is authenticated (`gh auth status`).
+- `$env:RSC_PSGalleryKeyFile` is set and points to a valid JSON file
+  containing `{ "apiKey": "..." }`.
+
+## How the version is determined
+
+`Get-NextReleaseVersionNumber.ps1` computes the next version as
+`Major.Minor.Schema`:
+
+| Component | Source |
+|-----------|--------|
+| **Major** | `### Major Version` field in `RubrikSecurityCloud/VERSION.md` |
+| **Minor** | `### Minor Version` field in `VERSION.md`, then adjusted (see rules below) |
+| **Schema** | Extracted from the `Description` field in `RubrikSecurityCloud.psd1` — updated automatically by the Jenkins schema pipeline |
+
+### Minor version adjustment rules
+
+| Condition | Result |
+|-----------|--------|
+| Major in `VERSION.md` is greater than the last released Major in `CHANGELOG.md` | Minor is reset to `0` |
+| `## Version TBD` block in `CHANGELOG.md` has entries under **New Features**, **Fixes**, or **Breaking Changes** (excluding `None`) | Minor is incremented by `1` |
+| Neither condition is true | Minor is unchanged |
+
+> Only the Major version should be edited manually in `VERSION.md`.
+> When the Major is bumped, reset Minor to `0` in `VERSION.md` as well.
+
+## Usage
+
+```powershell
+# Preview — prints every action without making changes (default)
+.\Utils\admin\Invoke-RscSdkAutoRelease.ps1
+
+# Execute — runs the full release for real
+.\Utils\admin\Invoke-RscSdkAutoRelease.ps1 -NotDry
+```
+
+## Pipeline steps
+
+| Step | Script | Always runs | Description |
+|------|--------|-------------|-------------|
+| 0a | `Test-RscSdkRelease.ps1`        | Yes | Confirms PSGallery version, GitHub release tag, and `main` branch all agree. Aborts if inconsistent. |
+| 0b | `Build-RscSdk.ps1`              | No (skipped in dry run) | Full build and test suite pre-flight. |
+| 1  | `Get-NextReleaseVersionNumber.ps1` | Yes | Computes next version. Aborts if it matches the currently published version — nothing to release. |
+| 2  | `Set-RscSdkVersion.ps1`         | No (skipped in dry run) | Writes the new version into `.psd1` and replaces `TBD` in `CHANGELOG.md`. |
+| 3  | `git commit` + `git push`       | No (skipped in dry run) | Commits and pushes the version bump to the current branch. |
+| 4  | `Test-RscSdkCandidate.ps1`      | Yes | Validates the branch is not `main`, changelog version matches `.psd1`, and the tag is not already published on GitHub. |
+| 5  | `New-RscSdkRelease.ps1`         | Yes (dry or live) | Resets `main` to `devel`, builds release config, force-pushes `main`, creates GitHub release, publishes to PSGallery. |
+| 6  | `Test-RscSdkRelease.ps1`        | No (skipped in dry run) | Post-release sanity check — confirms everything is coherent after publish. |
+
+## Abort conditions
+
+The script stops early (without making any changes) if:
+
+- Current release state is inconsistent (step 0a).
+- The computed next version equals the currently published version (step 1) —
+  this means there is nothing new to release.
+- Release candidate validation fails (step 4) — e.g. version mismatch or tag
+  already exists.
+
+## Troubleshooting
+
+| Problem | Resolution |
+|---------|------------|
+| "next version is the same as current" | Add entries to `## Version TBD` in `CHANGELOG.md` or bump the Major version in `VERSION.md`. |
+| "Version mismatch" at step 4 | Run step 2 manually: `Set-RscSdkVersion.ps1 -NewVersion <version>`. |
+| Build fails at step 0b | Fix the failing tests before releasing. |
+| PSGallery publish fails | Check `$env:RSC_PSGalleryKeyFile` and API key validity. |
+| `gh release create` fails | Check `gh auth status` and repo permissions. |

--- a/Utils/admin/Invoke-RscSdkAutoRelease.Tests.ps1
+++ b/Utils/admin/Invoke-RscSdkAutoRelease.Tests.ps1
@@ -84,3 +84,80 @@ Describe 'Invoke-RscSdkAutoRelease - VERSION.md update (step 2b)' {
         }
     }
 }
+
+Describe 'Invoke-RscSdkAutoRelease - Schema Update in changelog TBD block (step 1b)' {
+
+    BeforeAll {
+        function New-TempChangelog($tbdBody) {
+            $path = [System.IO.Path]::GetTempFileName()
+            @"
+# Changelog
+
+## Version TBD
+
+$tbdBody
+## Version 1.18.20260601
+
+Schema Update:
+- Automatic schema update
+
+New Features:
+- Some prior feature
+"@ | Set-Content -Path $path -NoNewline
+            return $path
+        }
+
+        # Mirrors the logic in Invoke-RscSdkAutoRelease step 1b.
+        function Ensure-SchemaUpdateEntry($path) {
+            $raw = Get-Content $path -Raw
+            $raw = $raw -replace "`r`n", "`n"
+            $tbdMatch = [regex]::Match($raw, '## Version TBD\n(.*?)(?=\n## Version |\z)', 'Singleline')
+            if ($tbdMatch.Success -and $tbdMatch.Value -notmatch 'Schema Update:') {
+                $raw = $raw -replace '(## Version TBD\n+)', "`$1Schema Update:`n- Automatic schema update`n`n"
+                Set-Content -Path $path -Value $raw -NoNewline
+            }
+        }
+    }
+
+    Context 'Schema Update section missing from TBD block' {
+        It 'inserts Schema Update before New Features when absent' {
+            $p = New-TempChangelog "New Features:`n`nFixes:`n`nBreaking Changes:`n"
+            try {
+                Ensure-SchemaUpdateEntry $p
+                $raw = Get-Content $p -Raw
+                $raw | Should -Match 'Schema Update:'
+                $raw | Should -Match '- Automatic schema update'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+
+        It 'places Schema Update before New Features' {
+            $p = New-TempChangelog "New Features:`n`nFixes:`n`nBreaking Changes:`n"
+            try {
+                Ensure-SchemaUpdateEntry $p
+                $raw = Get-Content $p -Raw
+                $raw.IndexOf('Schema Update:') | Should -BeLessThan $raw.IndexOf('New Features:')
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+
+        It 'inserts exactly one Schema Update entry' {
+            $p = New-TempChangelog "New Features:`n`nFixes:`n`nBreaking Changes:`n"
+            try {
+                Ensure-SchemaUpdateEntry $p
+                $raw = Get-Content $p -Raw
+                ([regex]::Matches($raw, 'Schema Update:')).Count | Should -Be 2  # one in TBD, one in prior release
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Schema Update section already present in TBD block' {
+        It 'does not add a duplicate Schema Update entry' {
+            $tbdBody = "Schema Update:`n- Automatic schema update`n`nNew Features:`n`nFixes:`n`nBreaking Changes:`n"
+            $p = New-TempChangelog $tbdBody
+            try {
+                Ensure-SchemaUpdateEntry $p
+                $raw = Get-Content $p -Raw
+                ([regex]::Matches($raw, 'Schema Update:')).Count | Should -Be 2  # TBD + prior release, no extra
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+    }
+}

--- a/Utils/admin/Invoke-RscSdkAutoRelease.Tests.ps1
+++ b/Utils/admin/Invoke-RscSdkAutoRelease.Tests.ps1
@@ -1,0 +1,86 @@
+Describe 'Invoke-RscSdkAutoRelease - VERSION.md update (step 2b)' {
+
+    BeforeAll {
+        function New-TempVersionMd($major, $minor, $schema) {
+            $path = [System.IO.Path]::GetTempFileName()
+            @"
+# PowerShell SDK Versioning
+
+### Major Version: $major
+### Minor Version: $minor
+### Schema Version: $schema
+"@ | Set-Content -Path $path -NoNewline
+            return $path
+        }
+
+        # Mirrors the regex replacements in Invoke-RscSdkAutoRelease step 2b.
+        function Update-VersionMd($path, $newMinor, $newSchema) {
+            $content = Get-Content $path -Raw
+            $content = $content -replace '(###\s+Minor Version:\s*)\d+',  "`${1}$newMinor"
+            $content = $content -replace '(###\s+Schema Version:\s*)\d+', "`${1}$newSchema"
+            Set-Content -Path $path -Value $content -NoNewline
+        }
+    }
+
+    Context 'Minor version update' {
+        It 'updates Minor Version field' {
+            $p = New-TempVersionMd 1 18 20260601
+            try {
+                Update-VersionMd $p 19 20260601
+                (Get-Content $p | Where-Object { $_ -match '###\s+Minor Version:' }) |
+                    Should -Match '###\s+Minor Version:\s*19'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+
+        It 'does not change Major Version when updating Minor' {
+            $p = New-TempVersionMd 1 18 20260601
+            try {
+                Update-VersionMd $p 19 20260601
+                (Get-Content $p | Where-Object { $_ -match '###\s+Major Version:' }) |
+                    Should -Match '###\s+Major Version:\s*1'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Schema version update' {
+        It 'updates Schema Version field' {
+            $p = New-TempVersionMd 1 18 20260601
+            try {
+                Update-VersionMd $p 18 20260901
+                (Get-Content $p | Where-Object { $_ -match '###\s+Schema Version:' }) |
+                    Should -Match '###\s+Schema Version:\s*20260901'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+
+        It 'does not change Minor Version when updating Schema only' {
+            $p = New-TempVersionMd 1 18 20260601
+            try {
+                Update-VersionMd $p 18 20260901
+                (Get-Content $p | Where-Object { $_ -match '###\s+Minor Version:' }) |
+                    Should -Match '###\s+Minor Version:\s*18'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Combined update' {
+        It 'updates both Minor and Schema in one pass' {
+            $p = New-TempVersionMd 1 18 20260601
+            try {
+                Update-VersionMd $p 19 20260901
+                (Get-Content $p | Where-Object { $_ -match '###\s+Minor Version:' }) |
+                    Should -Match '###\s+Minor Version:\s*19'
+                (Get-Content $p | Where-Object { $_ -match '###\s+Schema Version:' }) |
+                    Should -Match '###\s+Schema Version:\s*20260901'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+
+        It 'preserves Major Version after a combined update' {
+            $p = New-TempVersionMd 2 0 20260601
+            try {
+                Update-VersionMd $p 1 20260901
+                (Get-Content $p | Where-Object { $_ -match '###\s+Major Version:' }) |
+                    Should -Match '###\s+Major Version:\s*2'
+            } finally { Remove-Item $p -ErrorAction SilentlyContinue }
+        }
+    }
+}

--- a/Utils/admin/Invoke-RscSdkAutoRelease.ps1
+++ b/Utils/admin/Invoke-RscSdkAutoRelease.ps1
@@ -1,0 +1,134 @@
+<#
+.SYNOPSIS
+    Automatically compute the next release version and publish the SDK.
+
+.DESCRIPTION
+    Wrapper that drives the full release pipeline without manual version entry:
+
+    0. Verify the current release state is coherent — PSGallery version,
+       GitHub release tag, and main branch all agree (via Test-RscSdkRelease.ps1).
+       Aborts if the current state is inconsistent.
+       Then runs a build and test pre-flight (via Build-RscSdk.ps1).
+    1. Compute the next version from VERSION.md, CHANGELOG.md, and the .psd1
+       schema date (via Get-NextReleaseVersionNumber.ps1).
+       Aborts if the next version matches the currently published version.
+    2. Apply the version to the .psd1 and CHANGELOG.md
+       (via Set-RscSdkVersion.ps1).
+    3. Commit and push the version bump to the current branch.
+    4. Validate the release candidate (via Test-RscSdkCandidate.ps1).
+    5. Run the full release (via New-RscSdkRelease.ps1).
+    6. Verify the published release (via Test-RscSdkRelease.ps1).
+
+    Follows the release process defined in HOWTO_MAKE_A_RELEASE.md.
+    Runs in dry-run mode by default. Pass -NotDry to execute for real.
+
+.PARAMETER NotDry
+    Execute the release. Without this switch the script prints every action
+    it would take but makes no changes.
+
+.EXAMPLE
+    .\Utils\admin\Invoke-RscSdkAutoRelease.ps1
+
+.EXAMPLE
+    .\Utils\admin\Invoke-RscSdkAutoRelease.ps1 -NotDry
+#>
+param(
+    [switch]$NotDry = $false
+)
+
+$ErrorActionPreference = "Stop"
+
+$SdkRoot = Join-Path -Path $PSScriptRoot -ChildPath '..\..' -Resolve
+
+function Step($message) {
+    Write-Host "`n==> $message" -ForegroundColor Cyan
+}
+
+function RunIfNotDry([ScriptBlock]$block) {
+    if ($script:NotDry) {
+        Write-Host "Run: $($block.ToString().Trim())" -ForegroundColor Yellow
+        & $block
+    } else {
+        Write-Host "Dry run: $($block.ToString().Trim())" -ForegroundColor DarkGray
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 0. Verify current release state
+# ---------------------------------------------------------------------------
+Step "Verifying current release state"
+& "$PSScriptRoot\Test-RscSdkRelease.ps1"
+Write-Host "Current release state is coherent." -ForegroundColor Green
+
+Step "Build and test pre-flight"
+if ($NotDry) {
+    & "$SdkRoot\Utils\Build-RscSdk.ps1"
+    Write-Host "Build and tests passed." -ForegroundColor Green
+} else {
+    Write-Host "Dry run: skipping build and tests." -ForegroundColor DarkGray
+}
+
+# ---------------------------------------------------------------------------
+# 1. Compute next version and compare with current
+# ---------------------------------------------------------------------------
+Step "Computing next release version"
+$v = & "$PSScriptRoot\Get-NextReleaseVersionNumber.ps1"
+$nextVersion = "$($v.Major).$($v.Minor).$($v.Schema)"
+Write-Host "Next version:    $nextVersion"
+
+$currentVersion = & "$SdkRoot\Utils\Get-RscSdkVersion.ps1"
+Write-Host "Current version: $currentVersion"
+
+if ($nextVersion -eq $currentVersion) {
+    Write-Host "`nAbort: next version ($nextVersion) is the same as the current released version. Nothing to publish." -ForegroundColor Red
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# 2. Apply version to .psd1 and CHANGELOG.md
+# ---------------------------------------------------------------------------
+Step "Applying version $nextVersion"
+RunIfNotDry {
+    & "$PSScriptRoot\Set-RscSdkVersion.ps1" -NewVersion $nextVersion
+}
+
+# ---------------------------------------------------------------------------
+# 3. Commit and push version bump
+# ---------------------------------------------------------------------------
+Step "Committing and pushing version bump"
+RunIfNotDry {
+    Set-Location $SdkRoot
+    git add -u
+    git commit -m "Bump version to $nextVersion"
+    git push
+}
+
+# ---------------------------------------------------------------------------
+# 4. Validate release candidate
+# ---------------------------------------------------------------------------
+Step "Validating release candidate"
+& "$PSScriptRoot\Test-RscSdkCandidate.ps1"
+
+# ---------------------------------------------------------------------------
+# 5. Release
+# ---------------------------------------------------------------------------
+Step "Running release"
+if ($NotDry) {
+    & "$PSScriptRoot\New-RscSdkRelease.ps1" -NotDry
+} else {
+    & "$PSScriptRoot\New-RscSdkRelease.ps1"
+}
+
+# ---------------------------------------------------------------------------
+# 6. Post-release verification
+# ---------------------------------------------------------------------------
+Step "Verifying published release"
+RunIfNotDry {
+    & "$PSScriptRoot\Test-RscSdkRelease.ps1"
+}
+
+if ($NotDry) {
+    Write-Host "`nInvoke-RscSdkRelease complete. Version $nextVersion is live." -ForegroundColor Green
+} else {
+    Write-Host "`nDry run complete. Re-run with -NotDry to publish." -ForegroundColor Green
+}

--- a/Utils/admin/Invoke-RscSdkAutoRelease.ps1
+++ b/Utils/admin/Invoke-RscSdkAutoRelease.ps1
@@ -93,6 +93,18 @@ RunIfNotDry {
 }
 
 # ---------------------------------------------------------------------------
+# 2b. Update VERSION.md with the computed minor and schema versions
+# ---------------------------------------------------------------------------
+Step "Updating VERSION.md to Minor=$($v.Minor), Schema=$($v.Schema)"
+RunIfNotDry {
+    $versionMdPath = Join-Path $SdkRoot "RubrikSecurityCloud\VERSION.md"
+    $content = Get-Content $versionMdPath -Raw
+    $content = $content -replace '(###\s+Minor Version:\s*)\d+', "`${1}$($v.Minor)"
+    $content = $content -replace '(###\s+Schema Version:\s*)\d+', "`${1}$($v.Schema)"
+    Set-Content -Path $versionMdPath -Value $content -NoNewline
+}
+
+# ---------------------------------------------------------------------------
 # 3. Commit and push version bump
 # ---------------------------------------------------------------------------
 Step "Committing and pushing version bump"

--- a/Utils/admin/Invoke-RscSdkAutoRelease.ps1
+++ b/Utils/admin/Invoke-RscSdkAutoRelease.ps1
@@ -85,6 +85,24 @@ if ($nextVersion -eq $currentVersion) {
 }
 
 # ---------------------------------------------------------------------------
+# 1b. Ensure "Schema Update" entry exists in the TBD changelog block
+# ---------------------------------------------------------------------------
+Step "Ensuring 'Schema Update' section in CHANGELOG.md TBD block"
+RunIfNotDry {
+    $changelogPath = Join-Path $SdkRoot "CHANGELOG.md"
+    $raw = Get-Content $changelogPath -Raw
+    $raw = $raw -replace "`r`n", "`n"
+    $tbdMatch = [regex]::Match($raw, '## Version TBD\n(.*?)(?=\n## Version |\z)', 'Singleline')
+    if ($tbdMatch.Success -and $tbdMatch.Value -notmatch 'Schema Update:') {
+        $raw = $raw -replace '(## Version TBD\n+)', "`$1Schema Update:`n- Automatic schema update`n`n"
+        Set-Content -Path $changelogPath -Value $raw -NoNewline
+        Write-Host "Added 'Schema Update' section to TBD block." -ForegroundColor Green
+    } else {
+        Write-Host "'Schema Update' already present — no change needed." -ForegroundColor Green
+    }
+}
+
+# ---------------------------------------------------------------------------
 # 2. Apply version to .psd1 and CHANGELOG.md
 # ---------------------------------------------------------------------------
 Step "Applying version $nextVersion"

--- a/Utils/admin/Invoke-RscSdkAutoRelease.ps1
+++ b/Utils/admin/Invoke-RscSdkAutoRelease.ps1
@@ -115,7 +115,7 @@ RunIfNotDry {
 # ---------------------------------------------------------------------------
 Step "Updating VERSION.md to Minor=$($v.Minor), Schema=$($v.Schema)"
 RunIfNotDry {
-    $versionMdPath = Join-Path $SdkRoot "RubrikSecurityCloud\VERSION.md"
+    $versionMdPath = Join-Path $SdkRoot "VERSION.md"
     $content = Get-Content $versionMdPath -Raw
     $content = $content -replace '(###\s+Minor Version:\s*)\d+', "`${1}$($v.Minor)"
     $content = $content -replace '(###\s+Schema Version:\s*)\d+', "`${1}$($v.Schema)"

--- a/VERSION.md
+++ b/VERSION.md
@@ -9,7 +9,7 @@ The PowerShell SDK uses the versioning format `<Major>.<Minor>.<Schema>`:
 # Current Version
 
 This reflects the in-progress state of the SDK on GitHub, not the last published release.
-It drives the automated release process. Only the major version should be changed manually; when doing so, reset the minor version to 0.
+It drives the automated release process. Only the major version should be changed manually; optionally reset the minor version to 0 at the same time — if not, it will be reset to 0 automatically during the auto-release.
 
 ### Major Version: 1
 ### Minor Version: 18


### PR DESCRIPTION
## Summary:

- Adds Invoke-RscSdkAutoRelease.ps1 — a wrapper that drives the full release pipeline without manual version entry. Computes the next version automatically, applies it, commits, and delegates to the existing New-RscSdkRelease.ps1.
- Adds Get-NextReleaseVersionNumber.ps1 — computes the next Major.Minor.Schema version by reading VERSION.md for major version changes, the .psd1 description for the schema date, and CHANGELOG.md to determine whether the minor should be incremented.
- Adds RubrikSecurityCloud/VERSION.md and CHANGELOG.md combined — new source-of-truth file for the major and minor version numbers, decoupling them from the .psd1 (which is overwritten at release time).
- Adds Utils/admin/HOWTO_AUTO_RELEASE.md — documents the automated release flow, version computation rules, and PR changelog requirements.
- Updates README.md to link to the PR/changelog requirements so contributors know what's expected before opening a PR.

## Test plan:

- [x] Dry run: .\Utils\admin\Invoke-RscSdkAutoRelease.ps1 (no -NotDry) — verify it prints expected steps and computed version without making changes
- [x] Verify Get-NextReleaseVersionNumber.ps1 increments minor when CHANGELOG.md TBD block has entries, and holds minor when it doesn't
- [x] Verify the script aborts cleanly when the computed next version equals the currently published version
- [x] Run .\Utils\admin\Get-NextReleaseVersionNumber.Tests.ps1 to confirm all unit tests pass

## JIRA Issues:
SPARK-898452

## Revert Plan:
None