### PR TITLE
Update Set-RscMssqlLogShippingSecondary cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@
 New Features:
 
 Fixes:
+- Fix `Set-RscMssqlLogShippingSecondary`: the cmdlet body was a copy-paste from
+  `Remove-RscMssqlLiveMount` and called the wrong mutation. It now correctly calls
+  `updateMssqlLogShippingConfiguration` (to configure automatic reseed via
+  `-AutomaticReseed`) and `updateMssqlLogShippingConfigurationV1` (to change
+  `-State` and `-DisconnectStandbyUsers`). The non-functional `-Force` parameter
+  has been replaced with `-AutomaticReseed`, `-State`, and `-DisconnectStandbyUsers`
+  (#260)
 
 Breaking Changes:
+- `Set-RscMssqlLogShippingSecondary`: the `-Force` parameter is removed.
+  Use `-AutomaticReseed` (to enable/disable automatic reseed) or `-State`/`-DisconnectStandbyUsers`
+  (to change the secondary's operating state) instead.
 
 ## Version 1.18.20260601
 

--- a/Toolkit/Public/Set-RscMssqlLogShippingSecondary.ps1
+++ b/Toolkit/Public/Set-RscMssqlLogShippingSecondary.ps1
@@ -2,19 +2,37 @@
 function Set-RscMssqlLogShippingSecondary {
     <#
     .SYNOPSIS
-    Configures a SQL Server log shipping secondary database in Rubrik Security Cloud.
+    Updates the configuration of a SQL Server log shipping secondary database.
 
     .DESCRIPTION
-    Updates the configuration of a SQL Server log shipping secondary target.
-    Use this cmdlet to modify settings on an existing log shipping relationship
-    managed by Rubrik. The log shipping target object is typically obtained
-    from Get-RscMssqlLogShipping.
+    Modifies settings on an existing log shipping secondary target managed by
+    Rubrik. Two parameter sets are supported:
 
-    .PARAMETER MssqlLiveMount
-    Live Mount object returned from Get-RscMssqlLiveMount
+    - AutomaticReseed (default): enables or disables automatic reseed when the
+      primary transaction log chain breaks. Uses the -AutomaticReseed switch;
+      omitting the switch disables automatic reseed.
 
-    .PARAMETER Force
-    Forces the unmount of a database in the event Rubrik cannot connect to the SQL Server Instance or database. 
+    - State: changes the secondary's operating state (RESTORING or STANDBY)
+      and optionally disconnects standby users when log backups are applied.
+
+    The log shipping target object is typically obtained from
+    Get-RscMssqlLogShipping.
+
+    .PARAMETER RscMssqlLogShipping
+    A log shipping target object, typically obtained from Get-RscMssqlLogShipping.
+
+    .PARAMETER AutomaticReseed
+    Enable automatic reseed when the primary transaction log chain breaks.
+    Omit the switch to disable automatic reseed.
+
+    .PARAMETER State
+    The operating state of the log shipping secondary.
+    RESTORING: secondary is in restore mode (no read access).
+    STANDBY: secondary is in standby mode (read-only access).
+
+    .PARAMETER DisconnectStandbyUsers
+    Automatically disconnect users from the secondary when applying log backups.
+    Only applicable when using the State parameter set.
 
     .PARAMETER AsQuery
     Return the query object instead of running the query.
@@ -22,43 +40,60 @@ function Set-RscMssqlLogShippingSecondary {
     other data needed to build the main query.
 
     .EXAMPLE
-    Removes the live mount from the SQL Server and cleans up the share and files on the Rubrik cluster
-    $RscMssqlDatabase = Get-RscMssqlDatabase -Name AdventureWorks2019
-    Get-RscMssqlLiveMount -RscMssqlDatabase $RscMssqlDatabase -MountedDatabaseName AdventureWorks2019_LiveMount
-    Remove-RscMssqlLiveMount -MssqlLiveMount $RscMssqlLiveMount
-    .LINK
-    Schema reference:
-    https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
+    Enable automatic reseed on a log shipping secondary.
 
-    .PARAMETER RscMssqlLogShipping
-    A log shipping target object, typically obtained from Get-RscMssqlLogShipping.
-
-    .PARAMETER Force
-    Force the operation even if Rubrik cannot connect to the SQL Server instance.
+    $logShipping = Get-RscMssqlLogShipping -RscMssqlDatabase $db -SecondaryDatabaseName "AW_Secondary" -RscCluster $cluster
+    Set-RscMssqlLogShippingSecondary -RscMssqlLogShipping $logShipping -AutomaticReseed
 
     .EXAMPLE
-    # Update a log shipping secondary configuration
-    $logShipping = Get-RscMssqlLogShipping -Name "AdventureWorks2019"
+    Disable automatic reseed on a log shipping secondary.
+
+    $logShipping = Get-RscMssqlLogShipping -RscMssqlDatabase $db -SecondaryDatabaseName "AW_Secondary" -RscCluster $cluster
     Set-RscMssqlLogShippingSecondary -RscMssqlLogShipping $logShipping
 
     .EXAMPLE
-    # Pipe a log shipping target directly
-    Get-RscMssqlLogShipping -Name "AdventureWorks2019" | Set-RscMssqlLogShippingSecondary
+    Change the secondary to STANDBY mode and disconnect users on log apply.
+
+    $logShipping = Get-RscMssqlLogShipping -RscMssqlDatabase $db -SecondaryDatabaseName "AW_Secondary" -RscCluster $cluster
+    Set-RscMssqlLogShippingSecondary -RscMssqlLogShipping $logShipping -State STANDBY -DisconnectStandbyUsers
+
+    .LINK
+    Schema reference:
+    https://rubrikinc.github.io/rubrik-api-documentation/schema/reference
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = "AutomaticReseed")]
     Param(
         [Parameter(
-            Mandatory = $false, 
-            ValueFromPipeline = $true
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ParameterSetName = "AutomaticReseed"
         )]
-        [RubrikSecurityCloud.Types.MssqlLogShippingTarget]$RscMssqlLogShipping, 
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ParameterSetName = "State"
+        )]
+        [RubrikSecurityCloud.Types.MssqlLogShippingTarget]$RscMssqlLogShipping,
 
         [Parameter(
-            Mandatory = $false,
-            ValueFromPipelineByPropertyName = $false
+            ParameterSetName = "AutomaticReseed",
+            Mandatory = $false
         )]
-        [Switch]$Force,
+        [Switch]$AutomaticReseed,
+
+        [Parameter(
+            ParameterSetName = "State",
+            Mandatory = $true
+        )]
+        [ValidateSet("RESTORING", "STANDBY")]
+        [String]$State,
+
+        [Parameter(
+            ParameterSetName = "State",
+            Mandatory = $false
+        )]
+        [Switch]$DisconnectStandbyUsers,
 
         [Parameter(
             Mandatory = $false,
@@ -67,20 +102,44 @@ function Set-RscMssqlLogShippingSecondary {
         )]
         [Switch]$AsQuery
     )
-    
+
     Process {
-        Write-Debug "- Running Remove-RscMssqlLiveMount"
-        
-        #region Create Query
-        $query = New-RscMutation -Gql deleteMssqlLiveMount  
-        $query.Var.input = New-Object -TypeName RubrikSecurityCloud.Types.DeleteMssqlLiveMountInput
+        Write-Debug "- Running Set-RscMssqlLogShippingSecondary"
 
-        $query.Var.input.id = "$($MssqlLiveMount.Fid)"
-        $query.Var.input.force = $force
+        if ($PSCmdlet.ParameterSetName -eq "State") {
+            #region Create Query (updateMssqlLogShippingConfigurationV1)
+            $query = New-RscMutation -Gql updateMssqlLogShippingConfigurationV1
+            $query.Var.input = New-Object -TypeName RubrikSecurityCloud.Types.UpdateMssqlLogShippingConfigurationV1Input
+            $query.Var.input.Id = $RscMssqlLogShipping.Fid
+            $query.Var.input.Config = New-Object -TypeName RubrikSecurityCloud.Types.MssqlLogShippingUpdateInput
+            $query.Var.input.Config.MssqlLogShippingTargetStateOptions = New-Object -TypeName RubrikSecurityCloud.Types.MssqlLogShippingTargetStateOptionsInput
+            $query.Var.input.Config.MssqlLogShippingTargetStateOptions.ShouldDisconnectStandbyUsers = [bool]$DisconnectStandbyUsers
+            switch ($State) {
+                "RESTORING" {
+                    $query.Var.input.Config.MssqlLogShippingTargetStateOptions.State = "MSSQL_LOG_SHIPPING_OK_STATE_RESTORING"
+                }
+                "STANDBY" {
+                    $query.Var.input.Config.MssqlLogShippingTargetStateOptions.State = "MSSQL_LOG_SHIPPING_OK_STATE_STANDBY"
+                }
+            }
+            #endregion
+        } else {
+            #region Create Query (updateMssqlLogShippingConfiguration)
+            $query = New-RscMutation -Gql updateMssqlLogShippingConfiguration
+            $query.Var.input = New-Object -TypeName RubrikSecurityCloud.Types.UpdateMssqlLogShippingConfigurationInput
+            $query.Var.input.Id = $RscMssqlLogShipping.CdmId
+            $query.Var.input.ClusterUuid = $RscMssqlLogShipping.Cluster.Id
+            $query.Var.input.Config = New-Object -TypeName RubrikSecurityCloud.Types.MssqlLogShippingUpdateV2Input
+            if ($AutomaticReseed) {
+                $query.Var.input.Config.MakeupReseedLimit = 1
+            } else {
+                $query.Var.input.Config.MakeupReseedLimit = 0
+            }
+            #endregion
+        }
 
-        #endregion
         if ( $AsQuery ) { return $query }
         $result = $query.Invoke()
         $result
-    } 
+    }
 }

--- a/Toolkit/Tests/unit/Set-RscMssqlLogShippingSecondary.Tests.ps1
+++ b/Toolkit/Tests/unit/Set-RscMssqlLogShippingSecondary.Tests.ps1
@@ -1,0 +1,144 @@
+#Requires -Version 3
+<#
+.SYNOPSIS
+    Unit tests for Set-RscMssqlLogShippingSecondary.
+
+.DESCRIPTION
+    Verifies that the cmdlet builds the correct mutation and populates
+    input fields for each parameter set:
+
+    - AutomaticReseed (default): calls updateMssqlLogShippingConfiguration
+      and sets makeupReseedLimit to 1 (enabled) or 0 (disabled).
+
+    - State: calls updateMssqlLogShippingConfigurationV1 and sets the
+      secondary state and shouldDisconnectStandbyUsers flag.
+
+    Uses -AsQuery to inspect the built query without an API connection.
+    See Get-RscMssqlInstance.Tests.ps1 for notes on why the cmdlet is
+    dot-sourced directly into this scope.
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+    . "$PSScriptRoot\..\..\Public\Set-RscMssqlLogShippingSecondary.ps1"
+
+    $mockCluster = New-Object RubrikSecurityCloud.Types.Cluster
+    $mockCluster.Id = 'cluster-uuid-1'
+
+    $mockLogShipping = New-Object RubrikSecurityCloud.Types.MssqlLogShippingTarget
+    $mockLogShipping.Fid     = 'fid-1111'
+    $mockLogShipping.CdmId   = 'cdmid-2222'
+    $mockLogShipping.Cluster = $mockCluster
+}
+
+Describe 'Set-RscMssqlLogShippingSecondary — AutomaticReseed parameter set' {
+
+    It 'builds updateMssqlLogShippingConfiguration query with makeupReseedLimit=1 when -AutomaticReseed is present' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -AutomaticReseed `
+            -AsQuery
+
+        $query | Should -Not -BeNullOrEmpty
+        $query.Var.input.GetType().Name          | Should -Be 'UpdateMssqlLogShippingConfigurationInput'
+        $query.Var.input.Id                      | Should -Be $mockLogShipping.CdmId
+        $query.Var.input.ClusterUuid             | Should -Be $mockCluster.Id
+        $query.Var.input.Config.MakeupReseedLimit | Should -Be 1
+    }
+
+    It 'sets makeupReseedLimit=0 when -AutomaticReseed is absent' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -AsQuery
+
+        $query.Var.input.GetType().Name           | Should -Be 'UpdateMssqlLogShippingConfigurationInput'
+        $query.Var.input.Config.MakeupReseedLimit  | Should -Be 0
+    }
+
+    It 'uses CdmId (not Fid) for the input Id field' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -AsQuery
+
+        $query.Var.input.Id | Should -Be $mockLogShipping.CdmId
+        $query.Var.input.Id | Should -Not -Be $mockLogShipping.Fid
+    }
+
+    It 'invokes the query and returns the result' {
+        Mock Invoke-Rsc -MockWith {
+            $reply = New-Object RubrikSecurityCloud.Types.UpdateMssqlLogShippingConfigurationReply
+            $reply.ShouldDisconnectStandbyUsers = $false
+            return $reply
+        }
+
+        $result = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -AutomaticReseed
+
+        $result | Should -BeOfType [RubrikSecurityCloud.Types.UpdateMssqlLogShippingConfigurationReply]
+        Assert-MockCalled Invoke-Rsc -Times 1
+    }
+}
+
+Describe 'Set-RscMssqlLogShippingSecondary — State parameter set' {
+
+    It 'builds updateMssqlLogShippingConfigurationV1 query for RESTORING state' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -State RESTORING `
+            -AsQuery
+
+        $query | Should -Not -BeNullOrEmpty
+        $query.Var.input.GetType().Name | Should -Be 'UpdateMssqlLogShippingConfigurationV1Input'
+        $query.Var.input.Id             | Should -Be $mockLogShipping.Fid
+        $query.Var.input.Config.MssqlLogShippingTargetStateOptions.State |
+            Should -Be ([RubrikSecurityCloud.Types.MssqlLogShippingOkState]::MSSQL_LOG_SHIPPING_OK_STATE_RESTORING)
+        $query.Var.input.Config.MssqlLogShippingTargetStateOptions.ShouldDisconnectStandbyUsers |
+            Should -Be $false
+    }
+
+    It 'sets STANDBY state and ShouldDisconnectStandbyUsers=true when -DisconnectStandbyUsers is present' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -State STANDBY `
+            -DisconnectStandbyUsers `
+            -AsQuery
+
+        $query.Var.input.Config.MssqlLogShippingTargetStateOptions.State |
+            Should -Be ([RubrikSecurityCloud.Types.MssqlLogShippingOkState]::MSSQL_LOG_SHIPPING_OK_STATE_STANDBY)
+        $query.Var.input.Config.MssqlLogShippingTargetStateOptions.ShouldDisconnectStandbyUsers |
+            Should -Be $true
+    }
+
+    It 'sets ShouldDisconnectStandbyUsers=false when -DisconnectStandbyUsers is absent' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -State STANDBY `
+            -AsQuery
+
+        $query.Var.input.Config.MssqlLogShippingTargetStateOptions.ShouldDisconnectStandbyUsers |
+            Should -Be $false
+    }
+
+    It 'uses Fid (not CdmId) for the input Id field' {
+        $query = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -State RESTORING `
+            -AsQuery
+
+        $query.Var.input.Id | Should -Be $mockLogShipping.Fid
+        $query.Var.input.Id | Should -Not -Be $mockLogShipping.CdmId
+    }
+
+    It 'invokes the query and returns the result' {
+        Mock Invoke-Rsc -MockWith {
+            return [pscustomobject]@{ Status = 'QUEUED'; Id = 'job-1' }
+        }
+
+        $result = Set-RscMssqlLogShippingSecondary `
+            -RscMssqlLogShipping $mockLogShipping `
+            -State RESTORING
+
+        $result.Status | Should -Be 'QUEUED'
+        Assert-MockCalled Invoke-Rsc -Times 1
+    }
+}


### PR DESCRIPTION
## Summary:

- The cmdlet body was a copy-paste from Remove-RscMssqlLiveMount and called the wrong mutation entirely. It now correctly calls:
  - updateMssqlLogShippingConfiguration — to enable/disable automatic reseed (-AutomaticReseed switch)
  - updateMssqlLogShippingConfigurationV1 — to change -State (RESTORING/STANDBY) and -DisconnectStandbyUsers
- The non-functional -Force parameter is removed and replaced with -AutomaticReseed, -State, and -DisconnectStandbyUsers
- Adds Pester tests covering both parameter sets
**Breaking change:** -Force parameter is removed. Callers must switch to -AutomaticReseed or -State/-DisconnectStandbyUsers.

## Test Plan:
  - Added UT
  
## JIRA Issues:
SPARK-891713

## Revert Plan:
None