### PR TITLE
Fix doc generation

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/docs/GenerateDocs.ps1
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/docs/GenerateDocs.ps1
@@ -80,10 +80,10 @@ foreach ($memberItem in $xml.doc.members.member){
         if (-not $Quiet) { Write-Output("`nProcessing Cmdlet: " + $cmdletName) }
         #Write-Output("Opening markdownd for $cmdletName")
         
-        # TODO: SPARK-517965 SDK Build fails in GenerateDocs.ps1
-        # see https://rubrik.atlassian.net/browse/SPARK-517965
-        if ($cmdletName -eq "New-RscQueryAzureNative"){
-            Write-Warning("Skipping $cmdletName due to known issue SPARK-517965")
+        # TODO: SPARK-953829 SDK Build fails in GenerateDocs.ps1
+        # see https://rubrik.atlassian.net/browse/SPARK-953829
+        if ($cmdletName -eq "New-RscQueryAwsNative"){
+            Write-Warning("Skipping $cmdletName due to known issue SPARK-953829")
             continue
         }
 


### PR DESCRIPTION
## Summary:

- Update the GenerateDocs.ps1 workaround that skips a cmdlet known to cause doc generation failures
- The failing cmdlet changed from New-RscQueryAzureNative (SPARK-517965) to New-RscQueryAwsNative (SPARK-953829), so the skip condition and warning message are updated accordingly

## Test plan:

- [x] Run doc generation (GenerateDocs.ps1) and confirm it completes without errors
- [x] Confirm New-RscQueryAwsNative is skipped with the updated warning message
- [x] Confirm New-RscQueryAzureNative docs are now generated normally
  
## JIRA Issues:

SPARK-951049

## Revert Plan:
None