### PR TITLE
Quote MSBuild Exec paths so the SDK builds in directories with spaces

### DIFF
--- a/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
+++ b/RubrikSecurityCloud/RubrikSecurityCloud.PowerShell/RubrikSecurityCloud.PowerShell.csproj
@@ -113,7 +113,7 @@
   </Target>
 
   <Target Name="GeneratePSD1File" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net6.0'">
-    <Exec Command="pwsh -File $(ProjectDir)/UpdatePsd1.ps1" />
+    <Exec Command="pwsh -File &quot;$(ProjectDir)/UpdatePsd1.ps1&quot;" />
   </Target>
 
   <Target Name="CopySupportFiles" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net6.0'">
@@ -145,6 +145,6 @@
     <PropertyGroup>
       <_DocsQuietFlag Condition="'$(VerboseDocs)' != 'true'">-Quiet</_DocsQuietFlag>
     </PropertyGroup>
-    <Exec Command="pwsh -File $(ProjectDir)docs/GenerateDocs.ps1 -sourceXml $(TargetDir)RubrikSecurityCloud.PowerShell.xml -ModuleFilePath $(TargetDir)../RubrikSecurityCloud.psd1 -ModuleName RubrikSecurityCloud -OutputPath $(TargetDir) $(_DocsQuietFlag)" />
+    <Exec Command="pwsh -File &quot;$(ProjectDir)docs/GenerateDocs.ps1&quot; -sourceXml &quot;$(TargetDir)RubrikSecurityCloud.PowerShell.xml&quot; -ModuleFilePath &quot;$(TargetDir)../RubrikSecurityCloud.psd1&quot; -ModuleName RubrikSecurityCloud -OutputPath &quot;$(TargetDir)&quot; $(_DocsQuietFlag)" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- `GeneratePSD1File` and `GeneratePSDocs` invoke `pwsh -File $(ProjectDir)...` without quoting
- On a checkout whose path contains a space (e.g. `.../Open Source/...`), `pwsh` treats the path as multiple arguments and the post-build step fails with exit code 64
- Quote the script path and related `-sourceXml` / `-ModuleFilePath` / `-OutputPath` arguments

## Test plan
- [x] `pwsh -c "./Utils/Build-RscSdk.ps1 -NoClean -NoDocs"` from a directory whose path contains a space — build succeeds (`0 Error(s)`)
- [ ] `make build-nodocs` on a path without spaces (existing CI)