### PR TITLE
Fix Get-RscSnapshot -Latest returning the oldest snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version TBD
+
+Schema Update:
+
+New Features:
+
+Fixes:
+- Fix `Get-RscSnapshot -Latest` returning the oldest snapshot. The query now
+  sorts by creation time descending so `first = 1` is the most recent snapshot
+  (#218)
+
+Breaking Changes:
+
 ## Version 1.19.20260803
 
 Schema Update:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ New Features:
 Fixes:
 - Fix `Get-RscSnapshot -Latest` returning the oldest snapshot. The query now
   sorts by creation time descending so `first = 1` is the most recent snapshot
-  (#218)
+  (#266)
 
 Breaking Changes:
 

--- a/Toolkit/Public/Get-RscSnapshot.ps1
+++ b/Toolkit/Public/Get-RscSnapshot.ps1
@@ -230,7 +230,11 @@ function Get-RscSnapshot {
             }
 
             if ($PSBoundParameters.ContainsKey('latest')) {
+                # Default snapshot order is oldest-first. Without an explicit
+                # CREATION_TIME DESC sort, first=1 is the oldest snapshot.
                 $query.var.first = 1
+                $query.var.sortBy = [RubrikSecurityCloud.Types.SnapshotQuerySortByField]::CREATION_TIME
+                $query.var.sortOrder = [RubrikSecurityCloud.Types.SortOrder]::DESC
             }
 
             if ($BeforeTime -and $AfterTime) {

--- a/Toolkit/Tests/unit/Get-RscSnapshot.Tests.ps1
+++ b/Toolkit/Tests/unit/Get-RscSnapshot.Tests.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+Tests for Get-RscSnapshot, including -Latest sort order (discussion #218).
+#>
+BeforeAll {
+    . "$PSScriptRoot\..\UnitTestInit.ps1"
+}
+
+Describe -Name "Get-RscSnapshot -Latest" -Fixture {
+
+    BeforeAll {
+        $script:vm = New-Object RubrikSecurityCloud.Types.VsphereVm
+        $script:vm.Id = '00000000-0000-0000-0000-000000000000'
+    }
+
+    It -Name 'Latest query requests the newest snapshot by creation time' -Test {
+        $query = Get-RscSnapshot -InputObject $script:vm -Latest -AsQuery
+        $query | Should -Not -BeNullOrEmpty
+        $query.Var.first | Should -Be 1
+        $query.Var.sortBy | Should -Be ([RubrikSecurityCloud.Types.SnapshotQuerySortByField]::CREATION_TIME)
+        $query.Var.sortOrder | Should -Be ([RubrikSecurityCloud.Types.SortOrder]::DESC)
+        $gql = $query.GqlRequest().Query
+        $gql | Should -Match 'snapshotOfASnappableConnection'
+    }
+
+    It -Name 'List query does not pin first/sort to a single newest snapshot' -Test {
+        $query = Get-RscSnapshot -InputObject $script:vm -AsQuery
+        $query | Should -Not -BeNullOrEmpty
+        $query.Var.first | Should -BeNullOrEmpty
+        $query.Var.sortBy | Should -BeNullOrEmpty
+        $query.Var.sortOrder | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- `Get-RscSnapshot -Latest` only set `first = 1` and never set `sortBy` / `sortOrder`
- `snapshotOfASnappableConnection` returns snapshots oldest-first by default, so the first row is the oldest snapshot (users live-mounted 2019 snapshots as "latest")
- When `-Latest` is set, request `sortBy = CREATION_TIME` and `sortOrder = DESC` in addition to `first = 1`
- Add a unit test that `-AsQuery` includes those variables, and that a list query does not

Relates to discussion #218

## Test plan
- [x] `Invoke-Pester Toolkit/Tests/unit/Get-RscSnapshot.Tests.ps1` — 2 passed
- [x] Toolkit unit tests: new snapshot tests passed (existing unrelated AsQuery / Assert-MockCalled failures are pre-existing)
- [ ] Manual: `Get-RscVmwareVm -Name <vm> | Get-RscSnapshot -Latest` returns the newest snapshot by date