### PR TITLE
Fix Get-RscMssqlInstance ignoring -Name / -InstanceName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version TBD
+
+Schema Update:
+
+New Features:
+
+Fixes:
+- Fix `Get-RscMssqlInstance -Name` / `-InstanceName` being ignored. Named
+  instance lookups now return only that instance instead of every instance on
+  the host (#202)
+
+Breaking Changes:
+
 ## Version 1.19.20260803
 
 Schema Update:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ New Features:
 Fixes:
 - Fix `Get-RscMssqlInstance -Name` / `-InstanceName` being ignored. Named
   instance lookups now return only that instance instead of every instance on
-  the host (#202)
+  the host (#267)
 
 Breaking Changes:
 

--- a/Toolkit/Public/Get-RscMssqlInstance.ps1
+++ b/Toolkit/Public/Get-RscMssqlInstance.ps1
@@ -290,6 +290,12 @@ Return the query object instead of executing it.
                         }
                         foreach ($child in $childNodes) {
                             if ($child -is [RubrikSecurityCloud.Types.MssqlInstance] -and $seenIds.Add($child.id)) {
+                                # -Name defaults to MSSQLSERVER but is only applied when
+                                # the caller passed -Name / -InstanceName. Unfiltered
+                                # -HostName must still return every instance on the host.
+                                if ($PSBoundParameters.ContainsKey('Name') -and $child.Name -ne $Name) {
+                                    continue
+                                }
                                 $instances.Add($child)
                             }
                         }

--- a/Toolkit/Tests/unit/Get-RscMssqlInstance.Tests.ps1
+++ b/Toolkit/Tests/unit/Get-RscMssqlInstance.Tests.ps1
@@ -134,3 +134,45 @@ Describe 'Get-RscMssqlInstance -WindowsClusterName response flattening' {
         $result[0].Id | Should -Be 'wc-inst-1'
     }
 }
+
+Describe 'Get-RscMssqlInstance -Name / -InstanceName filter' {
+
+    BeforeAll {
+        Mock Invoke-Rsc -MockWith {
+            $inst1 = New-Object RubrikSecurityCloud.Types.MssqlInstance
+            $inst1.Id = 'inst-1'
+            $inst1.Name = 'INSTANCE-1'
+
+            $inst2 = New-Object RubrikSecurityCloud.Types.MssqlInstance
+            $inst2.Id = 'inst-2'
+            $inst2.Name = 'DEV01'
+
+            $ph = New-Object RubrikSecurityCloud.Types.PhysicalHost
+            $ph.ObjectType = [RubrikSecurityCloud.Types.HierarchyObjectTypeEnum]::PHYSICAL_HOST
+            $ph.DescendantConnection = New-Object RubrikSecurityCloud.Types.PhysicalHostDescendantTypeConnection
+            $ph.DescendantConnection.Nodes = New-Object -TypeName 'System.Collections.Generic.List[RubrikSecurityCloud.Types.PhysicalHostDescendantType]'
+            $ph.DescendantConnection.Nodes.Add($inst1)
+            $ph.DescendantConnection.Nodes.Add($inst2)
+
+            return [pscustomobject]@{ nodes = @($ph) }
+        }
+    }
+
+    It 'filters to the named instance when -Name is passed' {
+        $result = @(Get-RscMssqlInstance -HostName 'test-host' -Name DEV01)
+        $result.Count | Should -Be 1
+        $result[0].Id | Should -Be 'inst-2'
+        $result[0].Name | Should -Be 'DEV01'
+    }
+
+    It 'filters with the -InstanceName alias' {
+        $result = @(Get-RscMssqlInstance -HostName 'test-host' -InstanceName DEV01)
+        $result.Count | Should -Be 1
+        $result[0].Id | Should -Be 'inst-2'
+    }
+
+    It 'returns all instances on the host when -Name is omitted' {
+        $result = @(Get-RscMssqlInstance -HostName 'test-host')
+        $result.Count | Should -Be 2
+    }
+}


### PR DESCRIPTION
## Summary
- `Get-RscMssqlInstance -HostName <host> -InstanceName DEV01` accepted `-Name` / `-InstanceName` (and documented them) but never filtered the flattened instance list
- Callers received every SQL instance on the host instead of the named one
- When `-Name` or `-InstanceName` is passed, filter the collected `MssqlInstance` rows to that name
- `-HostName` without `-Name` still returns all instances on the host (existing tests and scripts)

Relates to discussion #202

## Test plan
- [x] `Invoke-Pester Toolkit/Tests/unit/Get-RscMssqlInstance.Tests.ps1` — 6 passed (3 existing flattening tests + 3 new filter tests)
- [ ] Manual: `Get-RscMssqlInstance -HostName $HostName -InstanceName DEV01` returns only DEV01